### PR TITLE
Use init container for installing the driver. Minor code cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators
 COPY . .
 RUN go build cmd/nvidia_gpu/nvidia_gpu.go
 
-FROM gcr.io/google_containers/cos-nvidia-driver-install@sha256:d9c3fea134fcc8850c110ea0bc0e9ff1cca6b474352712d2d8f2762a29d95327
+FROM golang:1.8.3-stretch
 COPY --from=builder /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators/nvidia_gpu /usr/bin/device_plugins
 RUN chmod a+x /usr/bin/device_plugins
 CMD ["/usr/bin/device_plugins"]

--- a/cmd/nvidia_gpu/nvidia_gpu.go
+++ b/cmd/nvidia_gpu/nvidia_gpu.go
@@ -59,10 +59,10 @@ type nvidiaGPUManager struct {
 	grpcServer     *grpc.Server
 }
 
-func NewNvidiaGPUManager() (*nvidiaGPUManager, error) {
+func NewNvidiaGPUManager() *nvidiaGPUManager {
 	return &nvidiaGPUManager{
 		devices: make(map[string]pluginapi.Device),
-	}, nil
+	}
 }
 
 // Discovers all NVIDIA GPU devices available on the local node by walking `/dev` directory.
@@ -264,16 +264,8 @@ func (ngm *nvidiaGPUManager) Serve(dpMountPath, kEndpoint, pEndpointPrefix strin
 func main() {
 	flag.Parse()
 	fmt.Printf("device-plugin started\n")
-	ngm, err := NewNvidiaGPUManager()
-	if err != nil {
-		if os.IsNotExist(err) {
-			// Sleep forever.
-			select {}
-		}
-		glog.Fatal(err)
-		os.Exit(1)
-	}
-	err = ngm.Start()
+	ngm := NewNvidiaGPUManager()
+	err := ngm.Start()
 	if err != nil {
 		glog.Fatal(err)
 		os.Exit(1)

--- a/cmd/nvidia_gpu/nvidia_gpu.go
+++ b/cmd/nvidia_gpu/nvidia_gpu.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"os/exec"
 	"path"
 	"regexp"
 	"sync"
@@ -94,16 +93,6 @@ func (ngm *nvidiaGPUManager) GetDeviceState(DeviceName string) string {
 // Discovers Nvidia GPU devices, installs device drivers, and sets up device
 // access environment.
 func (ngm *nvidiaGPUManager) Start() error {
-	// Install Nvidia device drivers.
-	// TODO: this part may be run as an init container outside device plugin.
-	fmt.Printf("Run installer script\n")
-	cmd := exec.Command("/bin/sh", "-c", "/usr/bin/nvidia-installer.sh")
-	stdoutStderr, err := cmd.CombinedOutput()
-	fmt.Printf("%s\n", stdoutStderr)
-	if err != nil {
-		return err
-	}
-
 	if _, err := os.Stat(nvidiaCtlDevice); err != nil {
 		return err
 	}
@@ -111,9 +100,10 @@ func (ngm *nvidiaGPUManager) Start() error {
 	if _, err := os.Stat(nvidiaUVMDevice); err != nil {
 		return err
 	}
+
 	ngm.defaultDevices = []string{nvidiaCtlDevice, nvidiaUVMDevice}
-	_, err = os.Stat(nvidiaUVMToolsDevice)
-	if !os.IsNotExist(err) {
+
+	if _, err := os.Stat(nvidiaUVMToolsDevice); !os.IsNotExist(err) {
 		ngm.defaultDevices = append(ngm.defaultDevices, nvidiaUVMToolsDevice)
 	}
 

--- a/cmd/nvidia_gpu/nvidia_gpu_test.go
+++ b/cmd/nvidia_gpu/nvidia_gpu_test.go
@@ -81,13 +81,12 @@ func TestRegister(t *testing.T) {
 
 func TestNvidiaGPUManager(t *testing.T) {
 	// Expects a valid GPUManager to be created.
-	testGpuManager, err := NewNvidiaGPUManager()
+	testGpuManager := NewNvidiaGPUManager()
 	as := assert.New(t)
 	as.NotNil(testGpuManager)
-	as.Nil(err)
 
 	// Tests discoverGPUs()
-	if _, err = os.Stat(nvidiaCtlDevice); err == nil {
+	if _, err := os.Stat(nvidiaCtlDevice); err == nil {
 		err = testGpuManager.discoverGPUs()
 		as.Nil(err)
 		gpus := reflect.ValueOf(testGpuManager).Elem().FieldByName("devices").Len()

--- a/device-plugin-daemonset.yaml
+++ b/device-plugin-daemonset.yaml
@@ -49,9 +49,10 @@ spec:
       - name: sysrq
         hostPath:
           path: /proc/sysrq-trigger
-      containers:
-      - image: "gcr.io/google_containers/device-plugin-gpu@sha256:f42e1dae81ba01564f64d8b7c824cc2287d0ac71988a3b1263d72ae48a475997"
-        command: ["/usr/bin/device_plugins"]
+      initContainers:
+      - image: "gcr.io/google-containers/cos-nvidia-driver-install@sha256:d9c3fea134fcc8850c110ea0bc0e9ff1cca6b474352712d2d8f2762a29d95327"
+        command: ["/bin/sh", "-c"]
+        args: ["usr/bin/nvidia-installer.sh"]
         name: nvidia-driver-installer
         resources:
           requests:
@@ -64,8 +65,6 @@ spec:
           - name: DEVICE_PLUGIN_ENABLED
             value: "true"
         volumeMounts:
-        - name: device-plugin
-          mountPath: /device-plugin
         - name: nvidia-overlay
           mountPath: /rootfs/nvidia
         - name: dev
@@ -74,4 +73,17 @@ spec:
           mountPath: /rootfs/etc/os-release
         - name: sysrq
           mountPath: /sysrq
-
+      containers:
+      - image: "gcr.io/google_containers/device-plugin-gpu@sha256:TODO_AFTER_CREATION"
+        command: ["/usr/bin/device_plugins"]
+        name: nvidia-device-plugin
+        resources:
+          requests:
+            cpu: 0.15
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: device-plugin
+          mountPath: /device-plugin
+        - name: dev
+          mountPath: /dev


### PR DESCRIPTION
Instead of installing them from inside the device plugin.
This makes it easier to control these two aspects separately.
We also switch to using the prepackaged installer image.
The resulting device-plugin image would be much smaller.
Need to update the device-plugin-gpu image sha once it is generated by container builder.
Also, minor code cleanup.