### PR TITLE
Build a minimal docker image. The resulting image is ~5MB.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.8.3-stretch as builder
+FROM golang:1.8-alpine as builder
 WORKDIR /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators
 COPY . .
 RUN go build cmd/nvidia_gpu/nvidia_gpu.go
+RUN chmod a+x /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators/nvidia_gpu
 
-FROM golang:1.8.3-stretch
+FROM alpine
 COPY --from=builder /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators/nvidia_gpu /usr/bin/device_plugins
-RUN chmod a+x /usr/bin/device_plugins
 CMD ["/usr/bin/device_plugins"]

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ presubmit: vet
 	@echo ">> checking file boilerplate"
 	@./build/check_boilerplate.sh
 
-TAG?=v0.5.1
-REGISTRY?=gcr.io/google_containers
+TAG?=$(shell git rev-parse HEAD)
+REGISTRY?=gcr.io/google-containers
 IMAGE=device-plugin-gpu
 
 build:


### PR DESCRIPTION
I tried using `FROM scratch` as well but that was causing some logging errors. So settled on `FROM alpine` which is small enough.