### PR TITLE
Supports device hot plugin.

### DIFF
--- a/cmd/nvidia_gpu/nvidia_gpu.go
+++ b/cmd/nvidia_gpu/nvidia_gpu.go
@@ -155,7 +155,7 @@ func (ngm *nvidiaGPUManager) ListAndWatch(emtpy *pluginapi.Empty, stream plugina
 			for _, dev := range ngm.devices {
 				resp.Devices = append(resp.Devices, &pluginapi.Device{dev.ID, dev.Health})
 			}
-			fmt.Printf("ListAndWatch: send devices %v", resp)
+			fmt.Printf("ListAndWatch: send devices %v\n", resp)
 			if err := stream.Send(resp); err != nil {
 				fmt.Printf("device-plugin: cannot update device states: %v\n", err)
 				ngm.grpcServer.Stop()
@@ -265,11 +265,12 @@ func main() {
 	flag.Parse()
 	fmt.Printf("device-plugin started\n")
 	ngm := NewNvidiaGPUManager()
-	err := ngm.Start()
-	if err != nil {
-		glog.Fatal(err)
-		os.Exit(1)
+	for {
+		err := ngm.Start()
+		if err == nil {
+			break
+		}
+		time.Sleep(5 * time.Second)
 	}
 	ngm.Serve(devicePluginMountPath, kubeletEndpoint, pluginEndpointPrefix)
-
 }


### PR DESCRIPTION
Instead of assuming nvidia gpu devices are already properly set up
when device plugin starts, wait till nvidia gpu devices appear.
This change is needed to run nvidia gpu device plugin as a system
addon that is automatically deployed on nodes with gpu devices,
while driver installation is still triggered by users and happen
at later time.