### PR TITLE
a small bug fix in nvidia_gpu_test.go

### DIFF
--- a/cmd/nvidia_gpu/nvidia_gpu_test.go
+++ b/cmd/nvidia_gpu/nvidia_gpu_test.go
@@ -112,8 +112,9 @@ func TestNvidiaGPUManager(t *testing.T) {
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout("unix", addr, timeout)
 		}))
-	defer conn.Close()
 	as.Nil(err)
+	defer conn.Close()
+
 	client := pluginapi.NewDevicePluginClient(conn)
 
 	// Tests ListAndWatch


### PR DESCRIPTION
Move ```defer conn.Close()``` after ```as.Nil(err)``` in case a grpc.Dial error