### PR TITLE
[k8s-1.8] Mount the whole directory where nvidia libraries and binaries are present.

### DIFF
--- a/cmd/nvidia_gpu/nvidia_gpu.go
+++ b/cmd/nvidia_gpu/nvidia_gpu.go
@@ -47,8 +47,11 @@ const (
 	kubeletEndpoint       = "kubelet.sock"
 	pluginEndpointPrefix  = "nvidiaGPU"
 	resourceName          = "nvidia.com/gpu"
-	ContainerPathPrefix   = "/usr/local/nvidia"
-	HostPathPrefix        = "/home/kubernetes/bin/nvidia"
+)
+
+var (
+	hostPathPrefix      = flag.String("host-path", "/home/kubernetes/bin/nvidia", "Path on the host that contains nvidia libraries. This will be mounted inside the container as '-container-path'")
+	containerPathPrefix = flag.String("container-path", "/usr/local/nvidia", "Path on the container that mounts '-host-path'")
 )
 
 // nvidiaGPUManager manages nvidia gpu devices.
@@ -191,13 +194,8 @@ func (ngm *nvidiaGPUManager) Allocate(ctx context.Context, rqt *pluginapi.Alloca
 			})
 		}
 		devRuntime.Mounts = append(devRuntime.Mounts, &pluginapi.Mount{
-			ContainerPath: path.Join(ContainerPathPrefix, "lib64"),
-			HostPath:      path.Join(HostPathPrefix, "lib"),
-			ReadOnly:      true,
-		})
-		devRuntime.Mounts = append(devRuntime.Mounts, &pluginapi.Mount{
-			ContainerPath: path.Join(ContainerPathPrefix, "bin"),
-			HostPath:      path.Join(HostPathPrefix, "bin"),
+			ContainerPath: *containerPathPrefix,
+			HostPath:      *hostPathPrefix,
 			ReadOnly:      true,
 		})
 		resp.Spec = append(resp.Spec, devRuntime)


### PR DESCRIPTION
The old installer had the libraries inside HostPathPrefix/lib and we were
mounting them as ContainerPathPrefix/lib64. The new installer has libraries
inside HostPathPrefix/lib64. To work-around this discrepancy, mount the whole
HostPathPrefix as ContainerPathPrefix.

The one potentially breaking affect of this change is when using the old
installer, the libraries inside the container will now be available as
/usr/local/nvidia/lib instead of /usr/local/nvidia/lib64. However, I tested
with the test cuda image and things worked fine.

Also, make hostPathPrefix and containerPathPrefix command-line flags, so that
they can be used with images other the COS.