### PR TITLE
Fix logic inversion error.

### DIFF
--- a/cmd/nvidia_gpu/nvidia_gpu.go
+++ b/cmd/nvidia_gpu/nvidia_gpu.go
@@ -103,7 +103,7 @@ func (ngm *nvidiaGPUManager) Start() error {
 
 	ngm.defaultDevices = []string{nvidiaCtlDevice, nvidiaUVMDevice}
 
-	if _, err := os.Stat(nvidiaUVMToolsDevice); err != nil {
+	if _, err := os.Stat(nvidiaUVMToolsDevice); err == nil {
 		ngm.defaultDevices = append(ngm.defaultDevices, nvidiaUVMToolsDevice)
 	}
 


### PR DESCRIPTION
Append the optional device when there's no error.
When there's error (probably device not found), skip.