### PR TITLE
Match gRPC socket path in Kubelet

### DIFF
--- a/cmd/nvidia_gpu/nvidia_gpu.go
+++ b/cmd/nvidia_gpu/nvidia_gpu.go
@@ -43,7 +43,7 @@ const (
 	nvidiaDeviceRE       = `^nvidia[0-9]*$`
 
 	// Device plugin settings.
-	pluginMountPath      = "/device-plugin"
+	pluginMountPath      = pluginapi.DevicePluginPath
 	kubeletEndpoint      = "kubelet.sock"
 	pluginEndpointPrefix = "nvidiaGPU"
 	resourceName         = "nvidia.com/gpu"


### PR DESCRIPTION
This PR use `MountPath` which matched Kubelet

@vishh @mindprince PTAL. Thanks!