### PR TITLE
Correct nvidia_gpu DaemonSet README.md for deployment status

### DIFF
--- a/cmd/nvidia_gpu/README.md
+++ b/cmd/nvidia_gpu/README.md
@@ -5,7 +5,7 @@ This directory contains the code for a Kubernetes [device plugin](https://kubern
 
 The daemonset manifest at https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/device-plugins/nvidia-gpu/daemonset.yaml can be used to deploy this device plugin to a cluster (1.9 onwards).
 
-In [GKE](https://g.co/gke), from 1.9 onwards, this daemonset is automatically deployed as an addon when you use nodes with accelerators attached.
+In [GKE](https://g.co/gke), from 1.9 onwards, this daemonset is automatically deployed as an addon. Note that daemonset pods are only scheduled on nodes with accelerators attached, they are not scheduled on nodes that don't have any accelerators attached.
 
 This device plugin requires that NVIDIA drivers and libraries are installed in a particular way.
 


### PR DESCRIPTION
- With GKE versions 1.9 onwards, the `nvidia-gpu-device-plugin` DaemonSet is automatically deployed (regardless of whether GPU nodes are present in the cluster).