### PR TITLE
Parameterize kernel download and nvidia installer options.

### DIFF
--- a/nvidia-driver-installer/ubuntu/entrypoint.sh
+++ b/nvidia-driver-installer/ubuntu/entrypoint.sh
@@ -24,6 +24,8 @@ NVIDIA_DRIVER_DOWNLOAD_URL="${NVIDIA_DRIVER_DOWNLOAD_URL:-$NVIDIA_DRIVER_DOWNLOA
 NVIDIA_INSTALL_DIR_HOST="${NVIDIA_INSTALL_DIR_HOST:-/var/lib/nvidia}"
 NVIDIA_INSTALL_DIR_CONTAINER="${NVIDIA_INSTALL_DIR_CONTAINER:-/usr/local/nvidia}"
 NVIDIA_INSTALLER_RUNFILE="$(basename "${NVIDIA_DRIVER_DOWNLOAD_URL}")"
+KERNEL_SOURCE_DOWNLOAD_COMMAND_DEFAULT='apt-get update && apt-get install -y linux-headers-${KERNEL_VERSION}'
+KERNEL_SOURCE_DOWNLOAD_COMMAND="${KERNEL_SOURCE_DOWNLOAD_COMMAND:-$KERNEL_SOURCE_DOWNLOAD_COMMAND_DEFAULT}"
 ROOT_MOUNT_DIR="${ROOT_MOUNT_DIR:-/root}"
 CACHE_FILE="${NVIDIA_INSTALL_DIR_CONTAINER}/.cache"
 KERNEL_VERSION="$(uname -r)"
@@ -68,7 +70,9 @@ update_container_ld_cache() {
 
 download_kernel_src() {
   echo "Downloading kernel sources..."
-  apt-get update && apt-get install -y linux-headers-${KERNEL_VERSION}
+  if [[ ${KERNEL_SOURCE_DOWNLOAD_COMMAND} ]]; then
+    eval ${KERNEL_SOURCE_DOWNLOAD_COMMAND}
+  fi
   echo "Downloading kernel sources... DONE."
 }
 
@@ -105,7 +109,7 @@ configure_nvidia_installation_dirs() {
   update_container_ld_cache
 
   # Install an exit handler to cleanup the overlayfs mount points.
-  trap "{ umount /lib/modules/${KERNEL_VERSION}/video; umount /usr/lib/x86_64-linux-gnu ; umount /usr/bin; }" EXIT
+  trap "{ umount /lib/modules/${KERNEL_VERSION}/video; umount /usr/lib/x86_64-linux-gnu ; umount -l /usr/bin; }" EXIT
   popd
   echo "Configuring installation directories... DONE."
 }
@@ -128,6 +132,7 @@ run_nvidia_installer() {
     --log-file-name="${NVIDIA_INSTALL_DIR_CONTAINER}/nvidia-installer.log" \
     --no-drm \
     --silent \
+    $(eval "echo ${NVIDIA_INSTALLER_EXTRA_ARGS}") \
     --accept-license
   popd
   echo "Running Nvidia installer... DONE."


### PR DESCRIPTION
This allows reusing the entrypoint by overriding how the kernel is downloaded and where to look for it.

As an alternative to #91, you can use this for centos by setting the following extra env in the daemonset:

```
          - name: KERNEL_SOURCE_DOWNLOAD_COMMAND
            value: 'yum install -y kernel-devel-${KERNEL_VERSION}'
          - name: NVIDIA_INSTALLER_EXTRA_ARGS
            value: '--kernel-source-path=/usr/src/kernels/${KERNEL_VERSION}'

```

It is also possible to use this for airgapped install provided the kernel-devel package and .run file are available on the host:

```
          - name: NVIDIA_DRIVER_DOWNLOAD_URL
            value: file:///root/usr/src/NVIDIA-Linux-x86_64-384.130.run
          - name: KERNEL_SOURCE_DOWNLOAD_COMMAND
            value: 'echo'
          - name: NVIDIA_INSTALLER_EXTRA_ARGS
            value: '--kernel-source-path=/root/usr/src/kernels/${KERNEL_VERSION}'
```