### PR TITLE
Sets LD_LIBRARY_PATH env in AllocateResponse so that gpu containers

### DIFF
--- a/pkg/gpu/nvidia/alpha_plugin.go
+++ b/pkg/gpu/nvidia/alpha_plugin.go
@@ -82,6 +82,10 @@ func (s *pluginServiceV1Alpha) Allocate(ctx context.Context, rqt *pluginapi.Allo
 		HostPath:      s.ngm.hostPathPrefix,
 		ReadOnly:      true,
 	})
+	// Add LD_LIBRARY_PATH env to work around the compatibility issue
+	// in cuda10 docker ubuntu base images.
+	resp.Envs = make(map[string]string)
+	resp.Envs["LD_LIBRARY_PATH"] = "/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
 	return resp, nil
 }
 

--- a/pkg/gpu/nvidia/alpha_plugin_test.go
+++ b/pkg/gpu/nvidia/alpha_plugin_test.go
@@ -147,6 +147,7 @@ func TestNvidiaGPUManagerAlphaAPI(t *testing.T) {
 	as.Nil(err)
 	as.Len(resp.Devices, 4)
 	as.Len(resp.Mounts, 1)
+	as.Len(resp.Envs, 1)
 	resp, err = client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		DevicesIDs: []string{"dev1", "dev2"},
 	})
@@ -160,6 +161,7 @@ func TestNvidiaGPUManagerAlphaAPI(t *testing.T) {
 	as.Contains(retDevices, "/dev/nvidiactl")
 	as.Contains(retDevices, "/dev/nvidia-uvm")
 	as.Contains(retDevices, "/dev/nvidia-uvm-tools")
+	as.Equal(resp.Envs["LD_LIBRARY_PATH"], "/usr/local/nvidia/lib:/usr/local/nvidia/lib64")
 	resp, err = client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		DevicesIDs: []string{"dev1", "dev3"},
 	})

--- a/pkg/gpu/nvidia/beta_plugin.go
+++ b/pkg/gpu/nvidia/beta_plugin.go
@@ -88,6 +88,11 @@ func (s *pluginServiceV1Beta1) Allocate(ctx context.Context, requests *pluginapi
 			HostPath:      s.ngm.hostPathPrefix,
 			ReadOnly:      true,
 		})
+		// Add LD_LIBRARY_PATH env to work around the compatibility issue
+		// in cuda10 docker ubuntu base images.
+		resp.Envs = make(map[string]string)
+		resp.Envs["LD_LIBRARY_PATH"] = "/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
+
 		resps.ContainerResponses = append(resps.ContainerResponses, resp)
 	}
 	return resps, nil

--- a/pkg/gpu/nvidia/beta_plugin_test.go
+++ b/pkg/gpu/nvidia/beta_plugin_test.go
@@ -102,6 +102,7 @@ func TestNvidiaGPUManagerBetaAPI(t *testing.T) {
 	as.Contains(retDevices, "/dev/nvidiactl")
 	as.Contains(retDevices, "/dev/nvidia-uvm")
 	as.Contains(retDevices, "/dev/nvidia-uvm-tools")
+	as.Equal(resp.ContainerResponses[0].Envs["LD_LIBRARY_PATH"], "/usr/local/nvidia/lib:/usr/local/nvidia/lib64")
 	resp, err = client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		ContainerRequests: []*pluginapi.ContainerAllocateRequest{
 			{DevicesIDs: []string{"dev1", "dev3"}}}})

--- a/pkg/gpu/nvidia/multiple_versions_test.go
+++ b/pkg/gpu/nvidia/multiple_versions_test.go
@@ -91,6 +91,7 @@ func TestNvidiaGPUManagerMultuipleAPIs(t *testing.T) {
 	as.Len(resp.ContainerResponses, 1)
 	as.Len(resp.ContainerResponses[0].Devices, 4)
 	as.Len(resp.ContainerResponses[0].Mounts, 1)
+	as.Len(resp.ContainerResponses[0].Envs, 1)
 	resp, err = clientBeta.Allocate(context.Background(), &pluginbeta.AllocateRequest{
 		ContainerRequests: []*pluginbeta.ContainerAllocateRequest{
 			{DevicesIDs: []string{"dev1", "dev2"}}}})
@@ -104,6 +105,7 @@ func TestNvidiaGPUManagerMultuipleAPIs(t *testing.T) {
 	as.Contains(retDevices, "/dev/nvidiactl")
 	as.Contains(retDevices, "/dev/nvidia-uvm")
 	as.Contains(retDevices, "/dev/nvidia-uvm-tools")
+	as.Equal(resp.ContainerResponses[0].Envs["LD_LIBRARY_PATH"], "/usr/local/nvidia/lib:/usr/local/nvidia/lib64")
 	resp, err = clientBeta.Allocate(context.Background(), &pluginbeta.AllocateRequest{
 		ContainerRequests: []*pluginbeta.ContainerAllocateRequest{
 			{DevicesIDs: []string{"dev1", "dev3"}}}})


### PR DESCRIPTION
built with Cuda10 image can find nvidia libraries at proper place.

Tested manually with Cuda10 based vector-add:
https://github.com/kubernetes/kubernetes/pull/73823