### PR TITLE
Fix the crashing issue when nvidia.ko is already loaded.

### DIFF
--- a/nvidia-driver-installer/minikube/entrypoint.sh
+++ b/nvidia-driver-installer/minikube/entrypoint.sh
@@ -174,13 +174,13 @@ run_nvidia_installer() {
 configure_cached_installation() {
   echo "Configuring cached driver installation..."
   update_container_ld_cache
-  if ! lsmod | grep -q -w 'nvidia'; then
+  if ! lsmod | grep -w 'nvidia' > /dev/null; then
     insmod "${NVIDIA_INSTALL_DIR_CONTAINER}/drivers/nvidia.ko"
   fi
-  if ! lsmod | grep -q -w 'nvidia_uvm'; then
+  if ! lsmod | grep -w 'nvidia_uvm' > /dev/null; then
     insmod "${NVIDIA_INSTALL_DIR_CONTAINER}/drivers/nvidia-uvm.ko"
   fi
-  if ! lsmod | grep -q -w 'nvidia_drm'; then
+  if ! lsmod | grep -w 'nvidia_drm' > /dev/null; then
     insmod "${NVIDIA_INSTALL_DIR_CONTAINER}/drivers/nvidia-drm.ko"
   fi
   echo "Configuring cached driver installation... DONE"

--- a/nvidia-driver-installer/ubuntu/entrypoint.sh
+++ b/nvidia-driver-installer/ubuntu/entrypoint.sh
@@ -136,10 +136,10 @@ run_nvidia_installer() {
 configure_cached_installation() {
   echo "Configuring cached driver installation..."
   update_container_ld_cache
-  if ! lsmod | grep -q -w 'nvidia'; then
+  if ! lsmod | grep -w 'nvidia' > /dev/null; then
     insmod "${NVIDIA_INSTALL_DIR_CONTAINER}/drivers/nvidia.ko"
   fi
-  if ! lsmod | grep -q -w 'nvidia_uvm'; then
+  if ! lsmod | grep -w 'nvidia_uvm' > /dev/null; then
     insmod "${NVIDIA_INSTALL_DIR_CONTAINER}/drivers/nvidia-uvm.ko"
   fi
   echo "Configuring cached driver installation... DONE"


### PR DESCRIPTION
In the expression `! lsmod | grep -q -w nvidia`, the `-q` option
of `grep` makes it shortcircuit, which chokes the `lsmod` command,
causing it exit with non-zero.
Let's remove the `-q` option and replace it with `> /dev/null`.

Fixes #90 