### PR TITLE
Also ppopulates PATH env in AllocateResponse so that gpu containers

### DIFF
--- a/pkg/gpu/nvidia/alpha_plugin.go
+++ b/pkg/gpu/nvidia/alpha_plugin.go
@@ -86,6 +86,7 @@ func (s *pluginServiceV1Alpha) Allocate(ctx context.Context, rqt *pluginapi.Allo
 	// in cuda10 docker ubuntu base images.
 	resp.Envs = make(map[string]string)
 	resp.Envs["LD_LIBRARY_PATH"] = "/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
+	resp.Envs["PATH"] = "/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	return resp, nil
 }
 

--- a/pkg/gpu/nvidia/alpha_plugin_test.go
+++ b/pkg/gpu/nvidia/alpha_plugin_test.go
@@ -147,7 +147,7 @@ func TestNvidiaGPUManagerAlphaAPI(t *testing.T) {
 	as.Nil(err)
 	as.Len(resp.Devices, 4)
 	as.Len(resp.Mounts, 1)
-	as.Len(resp.Envs, 1)
+	as.Len(resp.Envs, 2)
 	resp, err = client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		DevicesIDs: []string{"dev1", "dev2"},
 	})
@@ -162,6 +162,7 @@ func TestNvidiaGPUManagerAlphaAPI(t *testing.T) {
 	as.Contains(retDevices, "/dev/nvidia-uvm")
 	as.Contains(retDevices, "/dev/nvidia-uvm-tools")
 	as.Equal(resp.Envs["LD_LIBRARY_PATH"], "/usr/local/nvidia/lib:/usr/local/nvidia/lib64")
+	as.Equal(resp.Envs["PATH"], "/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 	resp, err = client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		DevicesIDs: []string{"dev1", "dev3"},
 	})

--- a/pkg/gpu/nvidia/beta_plugin.go
+++ b/pkg/gpu/nvidia/beta_plugin.go
@@ -92,6 +92,7 @@ func (s *pluginServiceV1Beta1) Allocate(ctx context.Context, requests *pluginapi
 		// in cuda10 docker ubuntu base images.
 		resp.Envs = make(map[string]string)
 		resp.Envs["LD_LIBRARY_PATH"] = "/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
+		resp.Envs["PATH"] = "/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 		resps.ContainerResponses = append(resps.ContainerResponses, resp)
 	}

--- a/pkg/gpu/nvidia/beta_plugin_test.go
+++ b/pkg/gpu/nvidia/beta_plugin_test.go
@@ -103,6 +103,7 @@ func TestNvidiaGPUManagerBetaAPI(t *testing.T) {
 	as.Contains(retDevices, "/dev/nvidia-uvm")
 	as.Contains(retDevices, "/dev/nvidia-uvm-tools")
 	as.Equal(resp.ContainerResponses[0].Envs["LD_LIBRARY_PATH"], "/usr/local/nvidia/lib:/usr/local/nvidia/lib64")
+	as.Equal(resp.ContainerResponses[0].Envs["PATH"], "/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 	resp, err = client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		ContainerRequests: []*pluginapi.ContainerAllocateRequest{
 			{DevicesIDs: []string{"dev1", "dev3"}}}})

--- a/pkg/gpu/nvidia/multiple_versions_test.go
+++ b/pkg/gpu/nvidia/multiple_versions_test.go
@@ -91,7 +91,7 @@ func TestNvidiaGPUManagerMultuipleAPIs(t *testing.T) {
 	as.Len(resp.ContainerResponses, 1)
 	as.Len(resp.ContainerResponses[0].Devices, 4)
 	as.Len(resp.ContainerResponses[0].Mounts, 1)
-	as.Len(resp.ContainerResponses[0].Envs, 1)
+	as.Len(resp.ContainerResponses[0].Envs, 2)
 	resp, err = clientBeta.Allocate(context.Background(), &pluginbeta.AllocateRequest{
 		ContainerRequests: []*pluginbeta.ContainerAllocateRequest{
 			{DevicesIDs: []string{"dev1", "dev2"}}}})
@@ -106,6 +106,7 @@ func TestNvidiaGPUManagerMultuipleAPIs(t *testing.T) {
 	as.Contains(retDevices, "/dev/nvidia-uvm")
 	as.Contains(retDevices, "/dev/nvidia-uvm-tools")
 	as.Equal(resp.ContainerResponses[0].Envs["LD_LIBRARY_PATH"], "/usr/local/nvidia/lib:/usr/local/nvidia/lib64")
+	as.Equal(resp.ContainerResponses[0].Envs["PATH"], "/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 	resp, err = clientBeta.Allocate(context.Background(), &pluginbeta.AllocateRequest{
 		ContainerRequests: []*pluginbeta.ContainerAllocateRequest{
 			{DevicesIDs: []string{"dev1", "dev3"}}}})


### PR DESCRIPTION
can find gpu tools at right places.

Kudos to @RenaudWasTaken for the suggestion in
https://github.com/GoogleCloudPlatform/container-engine-accelerators/commit/65ea3c06db230e2061a03c251ae7908d5eb25a03#r32400515