### PR TITLE
Add periodic check for gpu devices installed after plugin server starts.

### DIFF
--- a/cmd/nvidia_gpu/nvidia_gpu.go
+++ b/cmd/nvidia_gpu/nvidia_gpu.go
@@ -27,6 +27,7 @@ const (
 	// Device plugin settings.
 	kubeletEndpoint      = "kubelet.sock"
 	pluginEndpointPrefix = "nvidiaGPU"
+	devDirectory         = "/dev"
 )
 
 var (
@@ -38,7 +39,7 @@ var (
 func main() {
 	flag.Parse()
 	glog.Infoln("device-plugin started")
-	ngm := gpumanager.NewNvidiaGPUManager(*hostPathPrefix, *containerPathPrefix)
+	ngm := gpumanager.NewNvidiaGPUManager(*hostPathPrefix, *containerPathPrefix, devDirectory)
 	// Keep on trying until success. This is required
 	// because Nvidia drivers may not be installed initially.
 	for {

--- a/pkg/gpu/nvidia/alpha_plugin.go
+++ b/pkg/gpu/nvidia/alpha_plugin.go
@@ -17,6 +17,7 @@ package nvidia
 import (
 	"fmt"
 	"net"
+	"path"
 	"time"
 
 	"github.com/golang/glog"
@@ -63,8 +64,8 @@ func (s *pluginServiceV1Alpha) Allocate(ctx context.Context, rqt *pluginapi.Allo
 			return nil, fmt.Errorf("invalid allocation request with unhealthy device %s", id)
 		}
 		resp.Devices = append(resp.Devices, &pluginapi.DeviceSpec{
-			HostPath:      "/dev/" + id,
-			ContainerPath: "/dev/" + id,
+			HostPath:      path.Join(s.ngm.devDirectory, id),
+			ContainerPath: path.Join(s.ngm.devDirectory, id),
 			Permissions:   "mrw",
 		})
 	}

--- a/pkg/gpu/nvidia/beta_plugin.go
+++ b/pkg/gpu/nvidia/beta_plugin.go
@@ -17,6 +17,7 @@ package nvidia
 import (
 	"fmt"
 	"net"
+	"path"
 	"time"
 
 	"github.com/golang/glog"
@@ -69,8 +70,8 @@ func (s *pluginServiceV1Beta1) Allocate(ctx context.Context, requests *pluginapi
 				return nil, fmt.Errorf("invalid allocation request with unhealthy device %s", id)
 			}
 			resp.Devices = append(resp.Devices, &pluginapi.DeviceSpec{
-				HostPath:      "/dev/" + id,
-				ContainerPath: "/dev/" + id,
+				HostPath:      path.Join(s.ngm.devDirectory, id),
+				ContainerPath: path.Join(s.ngm.devDirectory, id),
 				Permissions:   "mrw",
 			})
 		}


### PR DESCRIPTION
New gpus that were installed after the device plugin server started were not being picked up by the plugin server and registered with the kubelet.