### PR TITLE
Revert "Sets LD_LIBRARY_PATH env in AllocateResponse so that gpu containers"

### DIFF
--- a/pkg/gpu/nvidia/alpha_plugin.go
+++ b/pkg/gpu/nvidia/alpha_plugin.go
@@ -82,10 +82,6 @@ func (s *pluginServiceV1Alpha) Allocate(ctx context.Context, rqt *pluginapi.Allo
 		HostPath:      s.ngm.hostPathPrefix,
 		ReadOnly:      true,
 	})
-	// Add LD_LIBRARY_PATH env to work around the compatibility issue
-	// in cuda10 docker ubuntu base images.
-	resp.Envs = make(map[string]string)
-	resp.Envs["LD_LIBRARY_PATH"] = "/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
 	return resp, nil
 }
 

--- a/pkg/gpu/nvidia/alpha_plugin_test.go
+++ b/pkg/gpu/nvidia/alpha_plugin_test.go
@@ -147,7 +147,6 @@ func TestNvidiaGPUManagerAlphaAPI(t *testing.T) {
 	as.Nil(err)
 	as.Len(resp.Devices, 4)
 	as.Len(resp.Mounts, 1)
-	as.Len(resp.Envs, 1)
 	resp, err = client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		DevicesIDs: []string{"dev1", "dev2"},
 	})
@@ -161,7 +160,6 @@ func TestNvidiaGPUManagerAlphaAPI(t *testing.T) {
 	as.Contains(retDevices, "/dev/nvidiactl")
 	as.Contains(retDevices, "/dev/nvidia-uvm")
 	as.Contains(retDevices, "/dev/nvidia-uvm-tools")
-	as.Equal(resp.Envs["LD_LIBRARY_PATH"], "/usr/local/nvidia/lib:/usr/local/nvidia/lib64")
 	resp, err = client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		DevicesIDs: []string{"dev1", "dev3"},
 	})

--- a/pkg/gpu/nvidia/beta_plugin.go
+++ b/pkg/gpu/nvidia/beta_plugin.go
@@ -88,11 +88,6 @@ func (s *pluginServiceV1Beta1) Allocate(ctx context.Context, requests *pluginapi
 			HostPath:      s.ngm.hostPathPrefix,
 			ReadOnly:      true,
 		})
-		// Add LD_LIBRARY_PATH env to work around the compatibility issue
-		// in cuda10 docker ubuntu base images.
-		resp.Envs = make(map[string]string)
-		resp.Envs["LD_LIBRARY_PATH"] = "/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
-
 		resps.ContainerResponses = append(resps.ContainerResponses, resp)
 	}
 	return resps, nil

--- a/pkg/gpu/nvidia/beta_plugin_test.go
+++ b/pkg/gpu/nvidia/beta_plugin_test.go
@@ -102,7 +102,6 @@ func TestNvidiaGPUManagerBetaAPI(t *testing.T) {
 	as.Contains(retDevices, "/dev/nvidiactl")
 	as.Contains(retDevices, "/dev/nvidia-uvm")
 	as.Contains(retDevices, "/dev/nvidia-uvm-tools")
-	as.Equal(resp.ContainerResponses[0].Envs["LD_LIBRARY_PATH"], "/usr/local/nvidia/lib:/usr/local/nvidia/lib64")
 	resp, err = client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		ContainerRequests: []*pluginapi.ContainerAllocateRequest{
 			{DevicesIDs: []string{"dev1", "dev3"}}}})

--- a/pkg/gpu/nvidia/multiple_versions_test.go
+++ b/pkg/gpu/nvidia/multiple_versions_test.go
@@ -91,7 +91,6 @@ func TestNvidiaGPUManagerMultuipleAPIs(t *testing.T) {
 	as.Len(resp.ContainerResponses, 1)
 	as.Len(resp.ContainerResponses[0].Devices, 4)
 	as.Len(resp.ContainerResponses[0].Mounts, 1)
-	as.Len(resp.ContainerResponses[0].Envs, 1)
 	resp, err = clientBeta.Allocate(context.Background(), &pluginbeta.AllocateRequest{
 		ContainerRequests: []*pluginbeta.ContainerAllocateRequest{
 			{DevicesIDs: []string{"dev1", "dev2"}}}})
@@ -105,7 +104,6 @@ func TestNvidiaGPUManagerMultuipleAPIs(t *testing.T) {
 	as.Contains(retDevices, "/dev/nvidiactl")
 	as.Contains(retDevices, "/dev/nvidia-uvm")
 	as.Contains(retDevices, "/dev/nvidia-uvm-tools")
-	as.Equal(resp.ContainerResponses[0].Envs["LD_LIBRARY_PATH"], "/usr/local/nvidia/lib:/usr/local/nvidia/lib64")
 	resp, err = clientBeta.Allocate(context.Background(), &pluginbeta.AllocateRequest{
 		ContainerRequests: []*pluginbeta.ContainerAllocateRequest{
 			{DevicesIDs: []string{"dev1", "dev3"}}}})


### PR DESCRIPTION
Reverts GoogleCloudPlatform/container-engine-accelerators#102

As discussed in https://github.com/GoogleCloudPlatform/container-engine-accelerators/pull/109#discussion_r276040748 overwriting common envs like $PATH or $LD_LIBRARY_PATH from device plugin may yield undesired behavior for users, so reverting this PR.

Nvidia has already added these envs back for cuda 10.0 and 10.1 ubuntu base images:
https://gitlab.com/nvidia/cuda/commit/f9138b4eec5213c45303c8ea657e714dc6e60ae7
Customer images rebuilt with the latest ubuntu base image should be free of previous issues due to the missing of these env variables.