### PR TITLE
Add mount for Vulkan installable client driver to support Vulkan workloads

### DIFF
--- a/cmd/nvidia_gpu/nvidia_gpu.go
+++ b/cmd/nvidia_gpu/nvidia_gpu.go
@@ -31,15 +31,20 @@ const (
 )
 
 var (
-	hostPathPrefix      = flag.String("host-path", "/home/kubernetes/bin/nvidia", "Path on the host that contains nvidia libraries. This will be mounted inside the container as '-container-path'")
-	containerPathPrefix = flag.String("container-path", "/usr/local/nvidia", "Path on the container that mounts '-host-path'")
-	pluginMountPath     = flag.String("plugin-directory", "/device-plugin", "The directory path to create plugin socket")
+	hostPathPrefix               = flag.String("host-path", "/home/kubernetes/bin/nvidia", "Path on the host that contains nvidia libraries. This will be mounted inside the container as '-container-path'")
+	containerPathPrefix          = flag.String("container-path", "/usr/local/nvidia", "Path on the container that mounts '-host-path'")
+	hostVulkanICDPathPrefix      = flag.String("host-vulkan-icd-path", "/home/kubernetes/bin/nvidia/vulkan/icd.d", "Path on the host that contains the Nvidia Vulkan installable client driver. This will be mounted inside the container as '-container-vulkan-icd-path'")
+	containerVulkanICDPathPrefix = flag.String("container-vulkan-icd-path", "/etc/vulkan/icd.d", "Path on the container that mounts '-host-vulkan-icd-path'")
+	pluginMountPath              = flag.String("plugin-directory", "/device-plugin", "The directory path to create plugin socket")
 )
 
 func main() {
 	flag.Parse()
 	glog.Infoln("device-plugin started")
-	ngm := gpumanager.NewNvidiaGPUManager(*hostPathPrefix, *containerPathPrefix, devDirectory)
+	mountPaths := []gpumanager.MountPath{
+		{HostPath: *hostPathPrefix, ContainerPath: *containerPathPrefix},
+		{HostPath: *hostVulkanICDPathPrefix, ContainerPath: *containerVulkanICDPathPrefix}}
+	ngm := gpumanager.NewNvidiaGPUManager(devDirectory, mountPaths)
 	// Keep on trying until success. This is required
 	// because Nvidia drivers may not be installed initially.
 	for {

--- a/pkg/gpu/nvidia/alpha_plugin.go
+++ b/pkg/gpu/nvidia/alpha_plugin.go
@@ -78,11 +78,13 @@ func (s *pluginServiceV1Alpha) Allocate(ctx context.Context, rqt *pluginapi.Allo
 		})
 	}
 
-	resp.Mounts = append(resp.Mounts, &pluginapi.Mount{
-		ContainerPath: s.ngm.containerPathPrefix,
-		HostPath:      s.ngm.hostPathPrefix,
-		ReadOnly:      true,
-	})
+	for _, mountPath := range s.ngm.mountPaths {
+		resp.Mounts = append(resp.Mounts, &pluginapi.Mount{
+			HostPath:      mountPath.HostPath,
+			ContainerPath: mountPath.ContainerPath,
+			ReadOnly:      true,
+		})
+	}
 	return resp, nil
 }
 

--- a/pkg/gpu/nvidia/alpha_plugin_test.go
+++ b/pkg/gpu/nvidia/alpha_plugin_test.go
@@ -88,7 +88,10 @@ func TestNvidiaGPUManagerAlphaAPI(t *testing.T) {
 	defer os.RemoveAll(testDevDir)
 
 	// Expects a valid GPUManager to be created.
-	testGpuManager := NewNvidiaGPUManager("/home/kubernetes/bin/nvidia", "/usr/local/nvidia", testDevDir)
+	mountPaths := []MountPath{
+		{HostPath: "/home/kubernetes/bin/nvidia", ContainerPath: "/usr/local/nvidia"},
+		{HostPath: "/home/kubernetes/bin/vulkan/icd.d", ContainerPath: "/etc/vulkan/icd.d"}}
+	testGpuManager := NewNvidiaGPUManager(testDevDir, mountPaths)
 	as := assert.New(t)
 	as.NotNil(testGpuManager)
 
@@ -162,7 +165,7 @@ func TestNvidiaGPUManagerAlphaAPI(t *testing.T) {
 	})
 	as.Nil(err)
 	as.Len(resp.Devices, 4)
-	as.Len(resp.Mounts, 1)
+	as.Len(resp.Mounts, 2)
 	resp, err = client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		DevicesIDs: []string{"nvidia1", "nvidia2"},
 	})

--- a/pkg/gpu/nvidia/beta_plugin.go
+++ b/pkg/gpu/nvidia/beta_plugin.go
@@ -84,11 +84,13 @@ func (s *pluginServiceV1Beta1) Allocate(ctx context.Context, requests *pluginapi
 			})
 		}
 
-		resp.Mounts = append(resp.Mounts, &pluginapi.Mount{
-			ContainerPath: s.ngm.containerPathPrefix,
-			HostPath:      s.ngm.hostPathPrefix,
-			ReadOnly:      true,
-		})
+		for _, mountPath := range s.ngm.mountPaths {
+			resp.Mounts = append(resp.Mounts, &pluginapi.Mount{
+				HostPath:      mountPath.HostPath,
+				ContainerPath: mountPath.ContainerPath,
+				ReadOnly:      true,
+			})
+		}
 		resps.ContainerResponses = append(resps.ContainerResponses, resp)
 	}
 	return resps, nil

--- a/pkg/gpu/nvidia/beta_plugin_test.go
+++ b/pkg/gpu/nvidia/beta_plugin_test.go
@@ -35,7 +35,10 @@ func TestNvidiaGPUManagerBetaAPI(t *testing.T) {
 	defer os.RemoveAll(testDevDir)
 
 	// Expects a valid GPUManager to be created.
-	testGpuManager := NewNvidiaGPUManager("/home/kubernetes/bin/nvidia", "/usr/local/nvidia", testDevDir)
+	mountPaths := []MountPath{
+		{HostPath: "/home/kubernetes/bin/nvidia", ContainerPath: "/usr/local/nvidia"},
+		{HostPath: "/home/kubernetes/bin/vulkan/icd.d", ContainerPath: "/etc/vulkan/icd.d"}}
+	testGpuManager := NewNvidiaGPUManager(testDevDir, mountPaths)
 	as := assert.New(t)
 	as.NotNil(testGpuManager)
 
@@ -106,7 +109,7 @@ func TestNvidiaGPUManagerBetaAPI(t *testing.T) {
 	as.Nil(err)
 	as.Len(resp.ContainerResponses, 1)
 	as.Len(resp.ContainerResponses[0].Devices, 4)
-	as.Len(resp.ContainerResponses[0].Mounts, 1)
+	as.Len(resp.ContainerResponses[0].Mounts, 2)
 	resp, err = client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		ContainerRequests: []*pluginapi.ContainerAllocateRequest{
 			{DevicesIDs: []string{"nvidia1", "nvidia2"}}}})

--- a/pkg/gpu/nvidia/manager.go
+++ b/pkg/gpu/nvidia/manager.go
@@ -47,24 +47,27 @@ var (
 
 // nvidiaGPUManager manages nvidia gpu devices.
 type nvidiaGPUManager struct {
-	hostPathPrefix      string
-	containerPathPrefix string
-	devDirectory        string
-	defaultDevices      []string
-	devices             map[string]pluginapi.Device
-	grpcServer          *grpc.Server
-	socket              string
-	stop                chan bool
-	devicesMutex        sync.Mutex
+	devDirectory   string
+	mountPaths     []MountPath
+	defaultDevices []string
+	devices        map[string]pluginapi.Device
+	grpcServer     *grpc.Server
+	socket         string
+	stop           chan bool
+	devicesMutex   sync.Mutex
 }
 
-func NewNvidiaGPUManager(hostPathPrefix, containerPathPrefix, devDirectory string) *nvidiaGPUManager {
+type MountPath struct {
+	HostPath      string
+	ContainerPath string
+}
+
+func NewNvidiaGPUManager(devDirectory string, mountPaths []MountPath) *nvidiaGPUManager {
 	return &nvidiaGPUManager{
-		hostPathPrefix:      hostPathPrefix,
-		containerPathPrefix: containerPathPrefix,
-		devDirectory:        devDirectory,
-		devices:             make(map[string]pluginapi.Device),
-		stop:                make(chan bool),
+		devDirectory: devDirectory,
+		mountPaths:   mountPaths,
+		devices:      make(map[string]pluginapi.Device),
+		stop:         make(chan bool),
 	}
 }
 

--- a/pkg/gpu/nvidia/multiple_versions_test.go
+++ b/pkg/gpu/nvidia/multiple_versions_test.go
@@ -36,7 +36,10 @@ func TestNvidiaGPUManagerMultuipleAPIs(t *testing.T) {
 	defer os.RemoveAll(testDevDir)
 
 	// Expects a valid GPUManager to be created.
-	testGpuManager := NewNvidiaGPUManager("/home/kubernetes/bin/nvidia", "/usr/local/nvidia", testDevDir)
+	mountPaths := []MountPath{
+		{HostPath: "/home/kubernetes/bin/nvidia", ContainerPath: "/usr/local/nvidia"},
+		{HostPath: "/home/kubernetes/bin/vulkan/icd.d", ContainerPath: "/etc/vulkan/icd.d"}}
+	testGpuManager := NewNvidiaGPUManager(testDevDir, mountPaths)
 	as := assert.New(t)
 	as.NotNil(testGpuManager)
 
@@ -108,7 +111,7 @@ func TestNvidiaGPUManagerMultuipleAPIs(t *testing.T) {
 	as.Nil(err)
 	as.Len(resp.ContainerResponses, 1)
 	as.Len(resp.ContainerResponses[0].Devices, 4)
-	as.Len(resp.ContainerResponses[0].Mounts, 1)
+	as.Len(resp.ContainerResponses[0].Mounts, 2)
 	resp, err = clientBeta.Allocate(context.Background(), &pluginbeta.AllocateRequest{
 		ContainerRequests: []*pluginbeta.ContainerAllocateRequest{
 			{DevicesIDs: []string{"nvidia1", "nvidia2"}}}})


### PR DESCRIPTION
Vulkan looks for a json file under /etc/vulkan/icd.d corresponding to the gpu driver being used. 