### PR TITLE
Mount Vulkan ICD onto host in nvidia-driver-installer.

### DIFF
--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -49,6 +49,9 @@ spec:
       - name: dev
         hostPath:
           path: /dev
+      - name: vulkan-icd-mount
+        hostPath:
+          path: /home/kubernetes/bin/nvidia/vulkan/icd.d
       - name: nvidia-install-dir-host
         hostPath:
           path: /home/kubernetes/bin/nvidia
@@ -68,11 +71,17 @@ spec:
             value: /home/kubernetes/bin/nvidia
           - name: NVIDIA_INSTALL_DIR_CONTAINER
             value: /usr/local/nvidia
+          - name: VULKAN_ICD_DIR_HOST
+            value: /home/kubernetes/bin/nvidia/vulkan/icd.d
+          - name: VULKAN_ICD_DIR_CONTAINER
+            value: /etc/vulkan/icd.d
           - name: ROOT_MOUNT_DIR
             value: /root
         volumeMounts:
         - name: nvidia-install-dir-host
           mountPath: /usr/local/nvidia
+        - name: vulkan-icd-mount
+          mountPath: /etc/vulkan/icd.d
         - name: dev
           mountPath: /dev
         - name: root-mount

--- a/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded.yaml
@@ -54,6 +54,9 @@ spec:
       - name: dev
         hostPath:
           path: /dev
+      - name: vulkan-icd-mount
+        hostPath:
+          path: /home/kubernetes/bin/nvidia/vulkan/icd.d
       - name: nvidia-install-dir-host
         hostPath:
           path: /home/kubernetes/bin/nvidia
@@ -74,11 +77,17 @@ spec:
             value: /home/kubernetes/bin/nvidia
           - name: NVIDIA_INSTALL_DIR_CONTAINER
             value: /usr/local/nvidia
+          - name: VULKAN_ICD_DIR_HOST
+            value: /home/kubernetes/bin/nvidia/vulkan/icd.d
+          - name: VULKAN_ICD_DIR_CONTAINER
+            value: /etc/vulkan/icd.d
           - name: ROOT_MOUNT_DIR
             value: /root
         volumeMounts:
         - name: nvidia-install-dir-host
           mountPath: /usr/local/nvidia
+        - name: vulkan-icd-mount
+          mountPath: /etc/vulkan/icd.d
         - name: dev
           mountPath: /dev
         - name: root-mount


### PR DESCRIPTION
Mount /etc/vulkan/icd.d within the nvidia driver installer onto the host under /home/kubernetes/bin/nvidia/vulkan/icd.d.