### PR TITLE
Update damonset.yaml to use the latest cos-gpu-installer

### DIFF
--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -56,7 +56,7 @@ spec:
         hostPath:
           path: /
       initContainers:
-      - image: gcr.io/cos-cloud/cos-gpu-installer@sha256:652687e88e9a2df8a0d529340ba21bb52a71450b36472c97ebed8c22e902b6c4
+      - image: gcr.io/cos-cloud/cos-gpu-installer:latest
         name: nvidia-driver-installer
         resources:
           requests:


### PR DESCRIPTION
The current version doesn't work with the latest COS image: https://github.com/kubernetes/kubernetes/pull/82766#issuecomment-532889581

The issue has already been fixed in https://github.com/GoogleCloudPlatform/cos-gpu-installer/commit/4f2d2ce218d48101d564ddfae5b49c6c99d9228b#diff-aa11924ff0d7142f19d3b2c354da55ed.

This file is used in tests only, so using the latest image is ideal.