### PR TITLE
Update stable from master

### DIFF
--- a/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded.yaml
@@ -42,9 +42,7 @@ spec:
               - key: cloud.google.com/gke-accelerator
                 operator: Exists
       tolerations:
-      - key: "nvidia.com/gpu"
-        effect: "NoSchedule"
-        operator: "Exists"
+      - operator: "Exists"
       hostNetwork: true
       hostPID: true
       volumes:


### PR DESCRIPTION
I've tested master nvidia-driver-installer on 1.13 and 1.16 clusters.