### PR TITLE
Add kustomization.yaml for cos

### DIFF
--- a/nvidia-driver-installer/cos/kustomization.yaml
+++ b/nvidia-driver-installer/cos/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- daemonset-preloaded.yaml


### PR DESCRIPTION
This will allow users to include this daemonset in their downstream builds by using
```yaml
resources:
- http://github.com/GoogleCloudPlatform/container-engine-accelerators.git//nvidia-driver-installer/cos/
```
in their own `kustomization.yaml` files