### PR TITLE
Pin nvidia-driver-installer to specific version

### DIFF
--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -63,7 +63,7 @@ spec:
         hostPath:
           path: /
       initContainers:
-      - image: gcr.io/cos-cloud/cos-gpu-installer:latest
+      - image: gcr.io/cos-cloud/cos-gpu-installer@sha256:8d86a652759f80595cafed7d3dcde3dc53f57f9bc1e33b27bc3cfa7afea8d483  # 'v20200701'
         name: nvidia-driver-installer
         resources:
           requests:


### PR DESCRIPTION
Due to an update in the cos-gpu-installer image, the GPU OSS test started failing (see: https://github.com/kubernetes/kubernetes/issues/93187). The goal of the OSS test is not to test the driver installer itself, so I'd like to pin the driver installer version to a specific version, to avoid breaking tests when new driver installers are released.