### PR TITLE
Upgrade device plugin base image and golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.9-alpine as builder
+FROM golang:1.15-alpine as builder
 WORKDIR /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators
 COPY . .
 RUN go build cmd/nvidia_gpu/nvidia_gpu.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-alpine as builder
+FROM golang:1.15 as builder
 WORKDIR /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators
 COPY . .
 RUN go build cmd/nvidia_gpu/nvidia_gpu.go
 RUN chmod a+x /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators/nvidia_gpu
 
-FROM alpine
+FROM gcr.io/distroless/base-debian10
 COPY --from=builder /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators/nvidia_gpu /usr/bin/nvidia-gpu-device-plugin
 CMD ["/usr/bin/nvidia-gpu-device-plugin", "-logtostderr"]


### PR DESCRIPTION
1. We're running a very old version of golang (1.9). Upgrade to current stable version (1.15).
2. Since we're planning to pull in nvml into our device plugin, alpine base image no longer satisfies the required dependencies. Upgrade to debian. This increases the image size from ~7MB to ~50MB.