### PR TITLE
Use string for CPU requests

### DIFF
--- a/nvidia-driver-installer/cos/daemonset-nvidia-v450.yaml
+++ b/nvidia-driver-installer/cos/daemonset-nvidia-v450.yaml
@@ -63,7 +63,7 @@ spec:
         name: nvidia-driver-installer
         resources:
           requests:
-            cpu: 0.15
+            cpu: "0.15"
         securityContext:
           privileged: true
         env:

--- a/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded.yaml
@@ -72,7 +72,7 @@ spec:
         name: nvidia-driver-installer
         resources:
           requests:
-            cpu: 0.15
+            cpu: "0.15"
         securityContext:
           privileged: true
         env:

--- a/nvidia-driver-installer/cos/daemonset-v2-preloaded.yaml
+++ b/nvidia-driver-installer/cos/daemonset-v2-preloaded.yaml
@@ -67,7 +67,7 @@ spec:
         - "install"
         resources:
           requests:
-            cpu: 0.15
+            cpu: "0.15"
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
When I was deploying the [`nvidia-driver-installer/cos/daemonset-preloaded.yaml`](https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml) manifest, I got this error:

```
Error: rpc error: code = Unknown desc = update dry-run for 'kube-system/nvidia-driver-installer' failed: failed to create typed patch object: .spec.template.spec.initContainers[name="nvidia-driver-installer"].resources.requests.cpu: expected string, got &value.valueUnstructured{Value:0.15}
```
According to the definition of the field, the value should be `string`:

```
$ kubectl explain daemonset.spec.template.spec.initContainers.resources.requests.cpu
KIND:     DaemonSet
VERSION:  apps/v1

FIELD:    cpu <string>
```

This PR is fixing that.