### PR TITLE
Device plugin metrics improvements

### DIFF
--- a/cmd/nvidia_gpu/nvidia_gpu.go
+++ b/cmd/nvidia_gpu/nvidia_gpu.go
@@ -39,7 +39,7 @@ var (
 	pluginMountPath                = flag.String("plugin-directory", "/device-plugin", "The directory path to create plugin socket")
 	enableContainerGPUMetrics      = flag.Bool("enable-container-gpu-metrics", false, "If true, the device plugin will expose GPU metrics for containers with allocated GPU")
 	gpuMetricsPort                 = flag.Int("gpu-metrics-port", 2112, "POrt on which GPU metrics for containers are exposed")
-	gpuMetricsCollectionIntervalMs = flag.Int("gpu-metrics-collection-interval", 2000, "Colection interval (in milli seconds) for container GPU metrics")
+	gpuMetricsCollectionIntervalMs = flag.Int("gpu-metrics-collection-interval", 30000, "Colection interval (in milli seconds) for container GPU metrics")
 )
 
 func main() {


### PR DESCRIPTION
Couple of improvements:
1. Stop reporting metrics for containers after they've terminated (periodically reset all metrics).
2. Report memory_used and memory_total in bytes.