### PR TITLE
Update cos-gpu-installer image

### DIFF
--- a/nvidia-driver-installer/cos/daemonset-nvidia-v450.yaml
+++ b/nvidia-driver-installer/cos/daemonset-nvidia-v450.yaml
@@ -59,7 +59,7 @@ spec:
         hostPath:
           path: /
       initContainers:
-      - image: gcr.io/cos-cloud/cos-gpu-installer@sha256:8d86a652759f80595cafed7d3dcde3dc53f57f9bc1e33b27bc3cfa7afea8d483
+      - image: gcr.io/cos-cloud/cos-gpu-installer@sha256:93f1abf0d6a27e14bebf43ffb00b8d819b20f6027012ad73306ba670bcac6c83
         name: nvidia-driver-installer
         resources:
           requests:


### PR DESCRIPTION
The old image had a bug that prevented the installer from working correctly on nodes with secure boot. The new image fixes this bug.