### PR TITLE
Report NUMA node to K8s for use by TopologyManager

### DIFF
--- a/pkg/gpu/nvidia/alpha_plugin_test.go
+++ b/pkg/gpu/nvidia/alpha_plugin_test.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
+	"github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/numa"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1alpha"
 )
 
@@ -91,7 +92,7 @@ func TestNvidiaGPUManagerAlphaAPI(t *testing.T) {
 	mountPaths := []MountPath{
 		{HostPath: "/home/kubernetes/bin/nvidia", ContainerPath: "/usr/local/nvidia"},
 		{HostPath: "/home/kubernetes/bin/vulkan/icd.d", ContainerPath: "/etc/vulkan/icd.d"}}
-	testGpuManager := NewNvidiaGPUManager(testDevDir, mountPaths)
+	testGpuManager := NewNvidiaGPUManager(testDevDir, mountPaths, numa.NewMockNumaNodeGetter(0))
 	as := assert.New(t)
 	as.NotNil(testGpuManager)
 

--- a/pkg/gpu/nvidia/beta_plugin.go
+++ b/pkg/gpu/nvidia/beta_plugin.go
@@ -42,7 +42,7 @@ func (s *pluginServiceV1Beta1) ListAndWatch(emtpy *pluginapi.Empty, stream plugi
 		if changed {
 			resp := new(pluginapi.ListAndWatchResponse)
 			for _, dev := range s.ngm.devices {
-				resp.Devices = append(resp.Devices, &pluginapi.Device{ID: dev.ID, Health: dev.Health})
+				resp.Devices = append(resp.Devices, &pluginapi.Device{ID: dev.ID, Health: dev.Health, Topology: dev.Topology})
 			}
 			glog.Infof("ListAndWatch: send devices %v\n", resp)
 			if err := stream.Send(resp); err != nil {

--- a/pkg/gpu/nvidia/multiple_versions_test.go
+++ b/pkg/gpu/nvidia/multiple_versions_test.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
+	"github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/numa"
 	pluginalpha "k8s.io/kubelet/pkg/apis/deviceplugin/v1alpha"
 	pluginbeta "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
@@ -39,7 +40,7 @@ func TestNvidiaGPUManagerMultuipleAPIs(t *testing.T) {
 	mountPaths := []MountPath{
 		{HostPath: "/home/kubernetes/bin/nvidia", ContainerPath: "/usr/local/nvidia"},
 		{HostPath: "/home/kubernetes/bin/vulkan/icd.d", ContainerPath: "/etc/vulkan/icd.d"}}
-	testGpuManager := NewNvidiaGPUManager(testDevDir, mountPaths)
+	testGpuManager := NewNvidiaGPUManager(testDevDir, mountPaths, numa.NewMockNumaNodeGetter(0))
 	as := assert.New(t)
 	as.NotNil(testGpuManager)
 

--- a/pkg/gpu/nvidia/numa/mock_numa_node_getter.go
+++ b/pkg/gpu/nvidia/numa/mock_numa_node_getter.go
@@ -1,0 +1,28 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package numa
+
+// NewMockNumaNodeGetter returns a mock NumaNodeGetter for unit testing
+func NewMockNumaNodeGetter(mockNumaNode int) NumaNodeGetter {
+	return &mockNumaNodeGetter{mockNumaNode: mockNumaNode}
+}
+
+type mockNumaNodeGetter struct {
+	mockNumaNode int
+}
+
+func (s *mockNumaNodeGetter) Get(deviceID string) (int, error) {
+	return s.mockNumaNode, nil
+}

--- a/pkg/gpu/nvidia/numa/null_numa_node_getter.go
+++ b/pkg/gpu/nvidia/numa/null_numa_node_getter.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package numa
+
+import (
+	"errors"
+)
+
+// NewNullNumaNodeGetter returns a NumaNodeGetter which always fails, for use when NUMA TopologyInfo is disabled.
+func NewNullNumaNodeGetter() NumaNodeGetter {
+	return &nullNumaNodeGetter{}
+}
+
+type nullNumaNodeGetter struct {
+}
+
+func (s *nullNumaNodeGetter) Get(deviceID string) (int, error) {
+	return -1, errors.New("Topology info disabled, won't try and get NUMA node")
+}

--- a/pkg/gpu/nvidia/numa/numa_node_getter.go
+++ b/pkg/gpu/nvidia/numa/numa_node_getter.go
@@ -1,0 +1,20 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package numa
+
+// NumaNodeGetter maps a device id (such as nvidia0) to a NUMA node.
+type NumaNodeGetter interface {
+	Get(deviceID string) (int, error)
+}

--- a/pkg/gpu/nvidia/numa/sys_numa_node_getter.go
+++ b/pkg/gpu/nvidia/numa/sys_numa_node_getter.go
@@ -1,0 +1,74 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package numa
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/pci"
+	"github.com/golang/glog"
+)
+
+type fileSystem interface {
+	ReadFile(filename string) ([]byte, error)
+}
+
+type realFileSystem struct{}
+
+func (realFileSystem) ReadFile(filename string) ([]byte, error) {
+	return ioutil.ReadFile(filename)
+}
+
+// NewSysNumaNodeGetter returns a NumaNodeGetter which maps device id to numa node by reading numa_node files under /sys.
+func NewSysNumaNodeGetter(sysd string, pdg pci.PciDetailsGetter) NumaNodeGetter {
+	return &sysNumaNodeGetter{sysDirectory: sysd, pciDetailsGetter: pdg, fs: realFileSystem{}}
+}
+
+// newSysNumaNodeGetterMockableFileSystem returns a NumaNodeGetter (like NewSysNumaNodeGetter) but allowing injection of a mock filesystem for testing.
+func newSysNumaNodeGetterMockableFileSystem(sysd string, pdg pci.PciDetailsGetter, fs fileSystem) NumaNodeGetter {
+	return &sysNumaNodeGetter{sysDirectory: sysd, pciDetailsGetter: pdg, fs: fs}
+}
+
+// Gets NUMA node by looking under /sys
+type sysNumaNodeGetter struct {
+	sysDirectory     string
+	pciDetailsGetter pci.PciDetailsGetter
+	fs               fileSystem
+}
+
+func (s *sysNumaNodeGetter) Get(deviceID string) (int, error) {
+	pciBusID, err := s.pciDetailsGetter.GetPciBusID(deviceID)
+	if err != nil {
+		return -1, fmt.Errorf("Failed to get pci bus id for %s: %v", deviceID, err)
+	}
+
+	filename := fmt.Sprintf("%s/bus/pci/devices/%s/numa_node", s.sysDirectory, strings.ToLower(pciBusID[4:]))
+	numaStr, err := s.fs.ReadFile(filename)
+	if err != nil {
+		return -1, fmt.Errorf("Failed to read file %s: %v", filename, err)
+	}
+
+	numa, err := strconv.ParseInt(strings.Trim(string(numaStr), "\n"), 10, 8)
+	if err != nil {
+		return -1, fmt.Errorf("Failed parse \"%s\" read from file %s: %v", numaStr, filename, err)
+	}
+
+	glog.Infof("Mapped device %s to pciBusID %s and NUMA node %d\n", deviceID, pciBusID, numa)
+
+	return int(numa), nil
+}

--- a/pkg/gpu/nvidia/numa/sys_numa_node_getter_test.go
+++ b/pkg/gpu/nvidia/numa/sys_numa_node_getter_test.go
@@ -1,0 +1,101 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package numa
+
+import (
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"syscall"
+	"testing"
+)
+
+type pciDetailsGetterMock struct {
+	mockBusID string
+}
+
+func (s *pciDetailsGetterMock) GetPciBusID(deviceID string) (string, error) {
+	return s.mockBusID, nil
+}
+
+type pciDetailsGetterErrorMock struct {
+	mockBusID string
+}
+
+func (s *pciDetailsGetterErrorMock) GetPciBusID(deviceID string) (string, error) {
+	return "", errors.New("Failed to read pci bus id")
+}
+
+type mockFileSystem struct {
+	files map[string][]byte
+}
+
+func (fs mockFileSystem) ReadFile(filename string) ([]byte, error) {
+	contents, exists := fs.files[filename]
+	if !exists {
+		return nil, &os.PathError{Op: "open", Path: filename, Err: syscall.Errno(2)}
+	}
+	return contents, nil
+}
+
+func Test_WhenFileIsGood_ReturnsContentsCorrectly(t *testing.T) {
+	testSysNumaNodeGetter(t, "1\n", 1, false)
+}
+
+func Test_WhenFileIsMissing_ReturnsError(t *testing.T) {
+	testSysNumaNodeGetter(t, "", -1, true)
+}
+
+func Test_WhenFileIsCorrupt_ReturnsError(t *testing.T) {
+	testSysNumaNodeGetter(t, "nonsense", -1, true)
+}
+
+func Test_WhenFailsToGetPciBusId_ReturnsError(t *testing.T) {
+	as := assert.New(t)
+
+	mockPci := pciDetailsGetterErrorMock{mockBusID: ""}
+	sut := NewSysNumaNodeGetter("a", &mockPci)
+
+	numaNode, err := sut.Get("/dev/nvidia4")
+
+	as.Equal(-1, numaNode)
+	as.NotNil(err)
+}
+
+func testSysNumaNodeGetter(t *testing.T, numaNodeFileContents string, expectedResult int, expectError bool) {
+	as := assert.New(t)
+
+	testSysDir := "/sys"
+	filename := fmt.Sprintf("%s/bus/pci/devices/0000_00_09.0/numa_node", testSysDir)
+
+	files := make(map[string][]byte)
+	if numaNodeFileContents != "" {
+		files[filename] = []byte(numaNodeFileContents)
+	}
+
+	mockPci := pciDetailsGetterMock{mockBusID: "00000000_00_09.0"}
+
+	sut := newSysNumaNodeGetterMockableFileSystem(testSysDir, &mockPci, mockFileSystem{files: files})
+
+	numaNode, err := sut.Get("/dev/nvidia4")
+
+	as.Equal(expectedResult, numaNode)
+	if expectError {
+		as.NotNil(err)
+	} else {
+		as.Nil(err)
+	}
+}

--- a/pkg/gpu/nvidia/pci/nvml_pci_details_getter.go
+++ b/pkg/gpu/nvidia/pci/nvml_pci_details_getter.go
@@ -1,0 +1,70 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pci
+
+import (
+	"fmt"
+	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml"
+	"github.com/golang/glog"
+	"strings"
+	"sync"
+)
+
+// NewNvmlPciDetailsGetter returns a PciDetailsGetter that uses Nvidia's NVML library to map device id to PCI bus id.
+func NewNvmlPciDetailsGetter() (PciDetailsGetter, error) {
+	return &nvmlPciDetailsGetter{deviceIDToBusID: nil}, nil
+}
+
+func (dg *nvmlPciDetailsGetter) init() {
+	numDevices, err := nvml.GetDeviceCount()
+	if err != nil {
+		glog.Errorf("Failed to get device count: %v", err)
+		return
+	}
+	glog.Infof("Found %d GPUs", numDevices)
+
+	deviceIDToBusID := make(map[string]string)
+	for deviceIndex := uint(0); deviceIndex < numDevices; deviceIndex++ {
+		device, err := nvml.NewDevice(deviceIndex)
+		if err != nil {
+			glog.Errorf("Failed to read device with index %d: %v", deviceIndex, err)
+			return
+		}
+		deviceID := strings.Replace(device.Path, "/dev/", "", 1)
+		pciBusID := device.PCI.BusID
+		glog.Infof("Mapped GPU %s to PCI bus id %s", deviceID, pciBusID)
+		deviceIDToBusID[deviceID] = pciBusID
+	}
+	dg.deviceIDToBusID = deviceIDToBusID
+}
+
+type nvmlPciDetailsGetter struct {
+	deviceIDToBusID map[string]string
+	initOnce        sync.Once
+}
+
+func (dg *nvmlPciDetailsGetter) GetPciBusID(deviceID string) (string, error) {
+	dg.initOnce.Do(func() { dg.init() })
+
+	if dg.deviceIDToBusID == nil {
+		return "", fmt.Errorf("Init of nvmlPciDetailsGetter has failed")
+	}
+
+	busID, exists := dg.deviceIDToBusID[deviceID]
+	if !exists {
+		return "", fmt.Errorf("Could not find GPU \"%s\"", deviceID)
+	}
+	return busID, nil
+}

--- a/pkg/gpu/nvidia/pci/pci_details_getter.go
+++ b/pkg/gpu/nvidia/pci/pci_details_getter.go
@@ -1,0 +1,20 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pci
+
+// PciDetailsGetter is used to map a device id (such as nvidia0) to a PCI bus id.
+type PciDetailsGetter interface {
+	GetPciBusID(deviceID string) (string, error)
+}


### PR DESCRIPTION
This PR makes the device plugin report GPU NUMA node for use by K8s TopologyManager.

First it uses NVML to map device id to pci bus id. Then it uses the pci bus id to find the relevant numa_node file under /sys, parses this file and returns the NUMA node to k8s via protobuf.

This feature is off by default, but can be enabled via the -topology command line option.