### PR TITLE
Catch critical Xid errors and mark GPUs unhealthy

### DIFF
--- a/pkg/gpu/nvidia/beta_plugin.go
+++ b/pkg/gpu/nvidia/beta_plugin.go
@@ -36,22 +36,18 @@ func (s *pluginServiceV1Beta1) GetDevicePluginOptions(ctx context.Context, e *pl
 
 func (s *pluginServiceV1Beta1) ListAndWatch(emtpy *pluginapi.Empty, stream pluginapi.DevicePlugin_ListAndWatchServer) error {
 	glog.Infoln("device-plugin: ListAndWatch start")
-	changed := true
+	if err := s.sendDevices(stream); err != nil {
+		return err
+	}
 	for {
-		if changed {
-			resp := new(pluginapi.ListAndWatchResponse)
-			for _, dev := range s.ngm.ListDevices() {
-				resp.Devices = append(resp.Devices, &pluginapi.Device{ID: dev.ID, Health: dev.Health})
-			}
-			glog.Infof("ListAndWatch: send devices %v\n", resp)
-			if err := stream.Send(resp); err != nil {
-				glog.Errorf("device-plugin: cannot update device states: %v\n", err)
-				s.ngm.grpcServer.Stop()
+		select {
+		case d := <-s.ngm.Health:
+			glog.Infof("device-plugin: %s device marked as %s", d.ID, d.Health)
+			s.ngm.devices[d.ID] = d
+			if err := s.sendDevices(stream); err != nil {
 				return err
 			}
 		}
-		time.Sleep(5 * time.Second)
-		changed = s.ngm.CheckDeviceStates()
 	}
 }
 
@@ -125,6 +121,20 @@ func RegisterWithV1Beta1Kubelet(kubeletEndpoint, pluginEndpoint, resourceName st
 
 	if _, err = client.Register(context.Background(), request); err != nil {
 		return fmt.Errorf("device-plugin: cannot register to kubelet service: %v", err)
+	}
+	return nil
+}
+
+func (s *pluginServiceV1Beta1) sendDevices(stream pluginapi.DevicePlugin_ListAndWatchServer) error {
+	resp := new(pluginapi.ListAndWatchResponse)
+	for _, dev := range s.ngm.ListDevices() {
+		resp.Devices = append(resp.Devices, &pluginapi.Device{ID: dev.ID, Health: dev.Health})
+	}
+	glog.Infof("ListAndWatch: send devices %v\n", resp)
+	if err := stream.Send(resp); err != nil {
+		glog.Errorf("device-plugin: cannot update device states: %v\n", err)
+		s.ngm.grpcServer.Stop()
+		return err
 	}
 	return nil
 }

--- a/pkg/gpu/nvidia/health_check/health_checker.go
+++ b/pkg/gpu/nvidia/health_check/health_checker.go
@@ -1,0 +1,168 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/util"
+	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml"
+	"github.com/golang/glog"
+
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+// GPUHealthChecker checks the health of nvidia GPUs. Note that with the current
+// device naming pattern in device manager, GPUHealthChecker will not work with
+// MIG devices.
+type GPUHealthChecker struct {
+	devices     map[string]pluginapi.Device
+	nvmlDevices map[string]*nvml.Device
+	health      chan pluginapi.Device
+	eventSet    nvml.EventSet
+	stop        chan bool
+}
+
+// NewGPUHealthChecker returns a GPUHealthChecker object for a given device name
+func NewGPUHealthChecker(devices map[string]pluginapi.Device, health chan pluginapi.Device) *GPUHealthChecker {
+	return &GPUHealthChecker{
+		devices:     devices,
+		nvmlDevices: make(map[string]*nvml.Device),
+		health:      health,
+		stop:        make(chan bool),
+	}
+}
+
+// Start registers NVML events and starts listening to them
+func (hc *GPUHealthChecker) Start() error {
+	glog.Info("Starting GPU Health Checker")
+
+	// Building mapping between device ID and their nvml represetation
+	count, err := nvml.GetDeviceCount()
+	if err != nil {
+		return fmt.Errorf("failed to get device count: %s", err)
+	}
+
+	glog.Infof("Found %d GPU devices", count)
+	for i := uint(0); i < count; i++ {
+		device, err := nvml.NewDeviceLite(i)
+		if err != nil {
+			return fmt.Errorf("failed to read device with index %d: %v", i, err)
+		}
+		deviceName, err := util.DeviceNameFromPath(device.Path)
+		if err != nil {
+			glog.Errorf("Invalid GPU device path found: %s. Skipping this device", device.Path)
+			continue
+		}
+
+		if _, ok := hc.devices[deviceName]; !ok {
+			// we only monitor the devices passed in
+			glog.Warningf("Ignoring device %s for health check.", deviceName)
+			continue
+		}
+
+		glog.Infof("Found device %s for health monitoring. UUID: %s", deviceName, device.UUID)
+		hc.nvmlDevices[deviceName] = device
+	}
+
+	hc.eventSet = nvml.NewEventSet()
+	for _, d := range hc.nvmlDevices {
+		gpu, _, _, err := nvml.ParseMigDeviceUUID(d.UUID)
+		if err != nil {
+			gpu = d.UUID
+		}
+
+		glog.Infof("Registering device %v. UUID: %s", d.Path, d.UUID)
+		err = nvml.RegisterEventForDevice(hc.eventSet, nvml.XidCriticalError, gpu)
+		if err != nil {
+			if strings.HasSuffix(err.Error(), "Not Supported") {
+				glog.Warningf("Warning: %s is too old to support healthchecking: %v. It will always be marked healthy.", d.Path, err)
+				continue
+			} else {
+				return fmt.Errorf("failed to register device %s for NVML eventSet: %v", d.Path, err)
+			}
+		}
+	}
+
+	go func() {
+		if err := hc.listenToEvents(); err != nil {
+			glog.Errorf("GPUHealthChecker listenToEvents error: %v", err)
+		}
+	}()
+
+	return nil
+}
+
+// listenToEvents listens to events from NVML to detect GPU critical errors
+func (hc *GPUHealthChecker) listenToEvents() error {
+	for {
+		select {
+		case <-hc.stop:
+			close(hc.stop)
+			return nil
+		default:
+		}
+
+		e, err := nvml.WaitForEvent(hc.eventSet, 5000)
+		if err != nil || e.Etype != nvml.XidCriticalError {
+			glog.Infof("XidCriticalError: Xid=%d, All devices will go unhealthy.", e.Edata)
+			continue
+		}
+
+		// Ignoring application errors. GPU should still be healthy
+		// See https://docs.nvidia.com/deploy/xid-errors/index.html#topic_4
+		if e.Edata == 31 || e.Edata == 43 || e.Edata == 45 {
+			continue
+		}
+
+		if e.UUID == nil || len(*e.UUID) == 0 {
+			// All devices are unhealthy
+			glog.Errorf("XidCriticalError: Xid=%d, All devices will go unhealthy.", e.Edata)
+			for id, d := range hc.devices {
+				d.Health = pluginapi.Unhealthy
+				hc.devices[id] = d
+				hc.health <- d
+			}
+			continue
+		}
+
+		for _, d := range hc.devices {
+			// Please see https://github.com/NVIDIA/gpu-monitoring-tools/blob/148415f505c96052cb3b7fdf443b34ac853139ec/bindings/go/nvml/nvml.h#L1424
+			// for the rationale why gi and ci can be set as such when the UUID is a full GPU UUID and not a MIG device UUID.
+			uuid := hc.nvmlDevices[d.ID].UUID
+			gpu, gi, ci, err := nvml.ParseMigDeviceUUID(uuid)
+			if err != nil {
+				gpu = uuid
+				gi = 0xFFFFFFFF
+				ci = 0xFFFFFFFF
+			}
+
+			if gpu == *e.UUID && gi == *e.GpuInstanceId && ci == *e.ComputeInstanceId {
+				glog.Errorf("XidCriticalError: Xid=%d on Device=%s, uuid=%s, the device will go unhealthy.", e.Edata, d.ID, uuid)
+				d.Health = pluginapi.Unhealthy
+				hc.devices[d.ID] = d
+				hc.health <- d
+			}
+		}
+	}
+}
+
+// Stop deletes the NVML events and stops the listening go routine
+func (hc *GPUHealthChecker) Stop() {
+	nvml.DeleteEventSet(hc.eventSet)
+	hc.stop <- true
+	<-hc.stop
+}

--- a/pkg/gpu/nvidia/manager.go
+++ b/pkg/gpu/nvidia/manager.go
@@ -68,6 +68,7 @@ type nvidiaGPUManager struct {
 	nvidiaUVMDevicePath string
 	gpuConfig           GPUConfig
 	migDeviceManager    mig.DeviceManager
+	Health              chan pluginapi.Device
 }
 
 type MountPath struct {
@@ -86,6 +87,7 @@ func NewNvidiaGPUManager(devDirectory string, mountPaths []MountPath, gpuConfig 
 		nvidiaUVMDevicePath: path.Join(devDirectory, nvidiaUVMDevice),
 		gpuConfig:           gpuConfig,
 		migDeviceManager:    mig.NewDeviceManager(devDirectory, procDir),
+		Health:              make(chan pluginapi.Device),
 	}
 }
 
@@ -339,5 +341,6 @@ func (ngm *nvidiaGPUManager) Stop() error {
 	}
 	ngm.stop <- true
 	<-ngm.stop
+	close(ngm.Health)
 	return nil
 }

--- a/pkg/gpu/nvidia/metrics/devices.go
+++ b/pkg/gpu/nvidia/metrics/devices.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/util"
 	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml"
 
 	"github.com/golang/glog"
@@ -108,7 +109,7 @@ func DiscoverGPUDevices() error {
 		if err != nil {
 			return fmt.Errorf("failed to read device with index %d: %v", i, err)
 		}
-		deviceName, err := deviceNameFromPath(device.Path)
+		deviceName, err := util.DeviceNameFromPath(device.Path)
 		if err != nil {
 			glog.Errorf("Invalid GPU device path found: %s. Skipping this device", device.Path)
 		}
@@ -127,12 +128,4 @@ func DeviceFromName(deviceName string) (nvml.Device, error) {
 	}
 
 	return *device, nil
-}
-
-func deviceNameFromPath(path string) (string, error) {
-	m := gpuPathRegex.FindStringSubmatch(path)
-	if len(m) != 2 {
-		return "", fmt.Errorf("path (%s) is not a valid GPU device path", path)
-	}
-	return m[1], nil
 }

--- a/pkg/gpu/nvidia/util/util.go
+++ b/pkg/gpu/nvidia/util/util.go
@@ -1,0 +1,29 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func DeviceNameFromPath(path string) (string, error) {
+	gpuPathRegex := regexp.MustCompile("/dev/(nvidia[0-9]+)$")
+	m := gpuPathRegex.FindStringSubmatch(path)
+	if len(m) != 2 {
+		return "", fmt.Errorf("path (%s) is not a valid GPU device path", path)
+	}
+	return m[1], nil
+}

--- a/pkg/gpu/nvidia/util/util_test.go
+++ b/pkg/gpu/nvidia/util/util_test.go
@@ -1,0 +1,32 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeviceNameFromPath(t *testing.T) {
+	as := assert.New(t)
+	name, err := DeviceNameFromPath("/dev/nvidia0")
+	as.Nil(err)
+	as.Equal("nvidia0", name)
+
+	name, err = DeviceNameFromPath("/dev/somethingelse0")
+	as.Error(err)
+	as.Contains(err.Error(), "is not a valid GPU device path")
+}


### PR DESCRIPTION
# What's changed
1. Added a `GPUHealthChecker` component which registers NVML events and listens to them.
2.  When an NVML event pops up, `GPUHealthChecker` will pass the device with updated healthness to `ListAndWatch` through a channel. `ListAndWatch` will update `ngm.devices` and send the latest device status to kubelet.
3. All `CheckHealth` logic will only be triggered when `--enable-health-monitoring` flag is used. This PR will be a no-op if the flag is not used, although the two `ListAndWatch` methods are slightly refactored.

# Test
* Added a piece of code to device manager that will periodically flap the health of the GPU (something like `ngm.devices['nvidia0'] = 'Unhealthy'`), deployed it to a cluster, and observed the allocatable fields in the node yaml. I can see that the number of allocatable GPUs changes accordingly. 
* Will need some further manual testing to test the NVML event part.