### PR TITLE
Adding Ubuntu nvidia-driver-installer builds for 18.04 and 20.04

### DIFF
--- a/build/boilerplate/boilerplate.py
+++ b/build/boilerplate/boilerplate.py
@@ -138,7 +138,7 @@ def get_regexs():
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile( 'YEAR' )
     # dates can be 2014, 2015 or 2016, company holder names can be anything
-    regexs["date"] = re.compile( '(2014|2015|2016|2017|2018|2019|2020)' )
+    regexs["date"] = re.compile( '(2014|2015|2016|2017|2018|2019|2020|2021)' )
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts

--- a/nvidia-driver-installer/ubuntu/Dockerfile
+++ b/nvidia-driver-installer/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2021 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+ARG base_image=ubuntu:16.04
+
+FROM ${base_image}
 
 RUN apt-get update && \
     apt-get install -y kmod gcc make curl && \

--- a/nvidia-driver-installer/ubuntu/Makefile
+++ b/nvidia-driver-installer/ubuntu/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2021 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,14 @@ REGISTRY?=gcr.io/google-containers
 IMAGE=ubuntu-nvidia-driver-installer
 
 container:
-	docker build --pull -t ${REGISTRY}/${IMAGE}:${TAG} .
+	docker build --build-arg base_image=ubuntu:16.04 --pull -t ${REGISTRY}/${IMAGE}:16.04-${TAG} -t ${REGISTRY}/${IMAGE}:${TAG} .
+	docker build --build-arg base_image=ubuntu:18.04 --pull -t ${REGISTRY}/${IMAGE}:18.04-${TAG} .
+	docker build --build-arg base_image=ubuntu:20.04 --pull -t ${REGISTRY}/${IMAGE}:20.04-${TAG} .
 
 push:
 	gcloud docker -- push ${REGISTRY}/${IMAGE}:${TAG}
+	gcloud docker -- push ${REGISTRY}/${IMAGE}:16.04-${TAG}
+	gcloud docker -- push ${REGISTRY}/${IMAGE}:18.04-${TAG}
+	gcloud docker -- push ${REGISTRY}/${IMAGE}:20.04-${TAG}
 
 .PHONY: container push

--- a/nvidia-driver-installer/ubuntu/README.md
+++ b/nvidia-driver-installer/ubuntu/README.md
@@ -1,10 +1,11 @@
+# container-engine-accelerators/nvidia-driver-installer/ubuntu
+
 This directory contains the following files:
 
 - `Dockerfile`
 - `Makefile`
 - `entrypoint.sh`
 - `daemonset.yaml`
-
 - `daemonset-preloaded.yaml`
 
 The first three files contain code for creating a docker container that can be

--- a/nvidia-driver-installer/ubuntu/entrypoint.sh
+++ b/nvidia-driver-installer/ubuntu/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2021 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ set -o pipefail
 set -u
 
 set -x
+NVIDIA_DRIVER_BRANCH="${NVIDIA_DRIVER_BRANCH:-tesla}"
 NVIDIA_DRIVER_VERSION="${NVIDIA_DRIVER_VERSION:-384.111}"
-NVIDIA_DRIVER_DOWNLOAD_URL_DEFAULT="https://us.download.nvidia.com/tesla/${NVIDIA_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${NVIDIA_DRIVER_VERSION}.run"
+NVIDIA_DRIVER_DOWNLOAD_URL_DEFAULT="https://us.download.nvidia.com/${NVIDIA_DRIVER_BRANCH}/${NVIDIA_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${NVIDIA_DRIVER_VERSION}.run"
 NVIDIA_DRIVER_DOWNLOAD_URL="${NVIDIA_DRIVER_DOWNLOAD_URL:-$NVIDIA_DRIVER_DOWNLOAD_URL_DEFAULT}"
 NVIDIA_INSTALL_DIR_HOST="${NVIDIA_INSTALL_DIR_HOST:-/var/lib/nvidia}"
 NVIDIA_INSTALL_DIR_CONTAINER="${NVIDIA_INSTALL_DIR_CONTAINER:-/usr/local/nvidia}"


### PR DESCRIPTION
This will build ubuntu-nvidia-driver-installer images for 18.04 and 20,04.