### PR TITLE
Only mark device unhealthy on Xid 48

### DIFF
--- a/pkg/gpu/nvidia/health_check/health_checker.go
+++ b/pkg/gpu/nvidia/health_check/health_checker.go
@@ -122,9 +122,9 @@ func (hc *GPUHealthChecker) listenToEvents() error {
 			continue
 		}
 
-		// Ignoring application errors. GPU should still be healthy
+		// Only marking device unhealthy on Double Bit ECC Error
 		// See https://docs.nvidia.com/deploy/xid-errors/index.html#topic_4
-		if e.Edata == 31 || e.Edata == 43 || e.Edata == 45 {
+		if e.Edata != 48 {
 			continue
 		}
 


### PR DESCRIPTION
We want to limit the scope of errors to begin with. We may want to make the list of errors configurable in future.