### PR TITLE
Extend health checker for MIG-enabled devices

### DIFF
--- a/pkg/gpu/nvidia/alpha_plugin.go
+++ b/pkg/gpu/nvidia/alpha_plugin.go
@@ -40,7 +40,7 @@ func (s *pluginServiceV1Alpha) ListAndWatch(emtpy *pluginapi.Empty, stream plugi
 		select {
 		case d := <-s.ngm.Health:
 			glog.Infof("device-plugin: %s device marked as %s", d.ID, d.Health)
-			s.ngm.devices[d.ID] = d
+			s.ngm.SetDeviceHealth(d.ID, d.Health)
 			if err := s.sendDevices(stream); err != nil {
 				return err
 			}

--- a/pkg/gpu/nvidia/beta_plugin.go
+++ b/pkg/gpu/nvidia/beta_plugin.go
@@ -43,7 +43,7 @@ func (s *pluginServiceV1Beta1) ListAndWatch(emtpy *pluginapi.Empty, stream plugi
 		select {
 		case d := <-s.ngm.Health:
 			glog.Infof("device-plugin: %s device marked as %s", d.ID, d.Health)
-			s.ngm.devices[d.ID] = d
+			s.ngm.SetDeviceHealth(d.ID, d.Health)
 			if err := s.sendDevices(stream); err != nil {
 				return err
 			}


### PR DESCRIPTION
This change checks whether MIG is enabled on each GPU device, and adds each MIG instance to the health check list if so.

Sample log when running on a MIG-enabled cluster
```
I0323 18:58:29.798138       1 nvidia_gpu.go:67] device-plugin started
I0323 18:58:29.798190       1 nvidia_gpu.go:74] Reading GPU config file: /etc/nvidia/gpu_config.json
I0323 18:58:29.798240       1 nvidia_gpu.go:83] Using gpu config: {1g.5gb}
I0323 18:58:29.798717       1 mig.go:176] Discovered GPU partition: nvidia0/gi10
I0323 18:58:29.798768       1 mig.go:176] Discovered GPU partition: nvidia0/gi11
I0323 18:58:29.798836       1 mig.go:176] Discovered GPU partition: nvidia0/gi12
...
I0323 18:58:29.897797       1 nvidia_gpu.go:107] Starting metrics server on port: 2112, endpoint path: /metrics, collection frequency: 30000
I0323 18:58:29.897831       1 metrics.go:84] Starting metrics server
I0323 18:58:29.897862       1 metrics.go:90] nvml initialized successfully. Driver version: 450.80.02
I0323 18:58:29.897872       1 devices.go:105] Foud 1 GPU devices
I0323 18:58:29.904068       1 devices.go:116] Found device nvidia0 for metrics collection
I0323 18:58:29.904107       1 health_checker.go:54] Starting GPU Health Checker
I0323 18:58:29.904112       1 health_checker.go:57] Healthchecker receives device nvidia0/gi7, device {nvidia0/gi7 Healthy nil {} 0}+
I0323 18:58:29.904153       1 health_checker.go:57] Healthchecker receives device nvidia0/gi8, device {nvidia0/gi8 Healthy nil {} 0}+
...
I0323 18:58:29.904186       1 health_checker.go:66] Found 1 GPU devices
I0323 18:58:29.904358       1 health_checker.go:134] HealthChecker detects MIG is enabled on device nvidia0
I0323 18:58:30.097572       1 health_checker.go:153] Found mig device nvidia0/gi7 for health monitoring. UUID: MIG-GPU-4e2a52cc-b4ab-0125-bc4c-6a746cf9487c/7/0
I0323 18:58:30.097620       1 health_checker.go:153] Found mig device nvidia0/gi8 for health monitoring. UUID: MIG-GPU-4e2a52cc-b4ab-0125-bc4c-6a746cf9487c/8/0
I0323 18:58:30.097638       1 health_checker.go:153] Found mig device nvidia0/gi9 for health monitoring. UUID: MIG-GPU-4e2a52cc-b4ab-0125-bc4c-6a746cf9487c/9/0
...
I0323 18:58:30.097774       1 health_checker.go:102] Registering device /dev/nvidia0. UUID: MIG-GPU-4e2a52cc-b4ab-0125-bc4c-6a746cf9487c/7/0
I0323 18:58:30.097915       1 health_checker.go:102] Registering device /dev/nvidia0. UUID: MIG-GPU-4e2a52cc-b4ab-0125-bc4c-6a746cf9487c/8/0
...
```