### PR TITLE
Remove version override from nvidia driver installer for MIG

### DIFF
--- a/nvidia-driver-installer/cos/daemonset-nvidia-mig.yaml
+++ b/nvidia-driver-installer/cos/daemonset-nvidia-mig.yaml
@@ -67,7 +67,6 @@ spec:
           path: /etc/nvidia
       initContainers:
       - image: "cos-nvidia-installer:fixed"
-        command: ["./cos-gpu-installer", "install", "--version=450.80.02"]
         imagePullPolicy: Never
         name: nvidia-driver-installer
         resources:


### PR DESCRIPTION
Now that the default NVIDIA GPU driver version used by cos is already > 450.80.02, we no longer need this override.