### PR TITLE
remove redundant CheckDevicePaths code

### DIFF
--- a/pkg/gpu/nvidia/manager.go
+++ b/pkg/gpu/nvidia/manager.go
@@ -205,9 +205,6 @@ func (ngm *nvidiaGPUManager) CheckDevicePaths() error {
 
 // Discovers Nvidia GPU devices and sets up device access environment.
 func (ngm *nvidiaGPUManager) Start() error {
-	if err := ngm.CheckDevicePaths(); err != nil {
-		return fmt.Errorf("error checking device paths: %v", err)
-	}
 	ngm.defaultDevices = []string{ngm.nvidiaCtlDevicePath, ngm.nvidiaUVMDevicePath}
 
 	nvidiaModesetDevicePath := path.Join(ngm.devDirectory, nvidiaModesetDevice)


### PR DESCRIPTION
ngm.CheckDevicePaths() is called in 
```
	for {
		err := ngm.CheckDevicePaths()
		if err == nil {
			if err = ngm.Start(); err == nil {
				break
			}
		}
		// Use non-default level to avoid log spam.
		glog.V(3).Infof("nvidiaGPUManager.CheckDevicePaths() failed: %v", err)
		time.Sleep(5 * time.Second)
	}
```
there is no need to call it again inside of ngm.Start()