### PR TITLE
Fix `/home/kubernetes/bin/nvidia is not a directory`

### DIFF
--- a/cmd/nvidia_gpu/device-plugin.yaml
+++ b/cmd/nvidia_gpu/device-plugin.yaml
@@ -38,6 +38,7 @@ spec:
       - name: nvidia
         hostPath:
             path: /home/kubernetes/bin/nvidia
+            type: DirectoryOrCreate
       - name: pod-resources
         hostPath:
             path: /var/lib/kubelet/pod-resources


### PR DESCRIPTION
If nothing exists at  /home/kubernetes/bin/nvidia, an empty directory will be created.

When creating a new GKE cluster with GPU, the pods of `nvidia-gpu-device-plugin` DaemonSet keep `ContainerCreating` status. With the following messages:
```
MountVolume.SetUp failed for volume "nvidia" : hostPath type check failed: /home/kubernetes/bin/nvidia is not a directory
```