### PR TITLE
Add the ability to export GPU metrics on the node level

### DIFF
--- a/cmd/nvidia_gpu/device-plugin.yaml
+++ b/cmd/nvidia_gpu/device-plugin.yaml
@@ -1,3 +1,4 @@
+# NOTE: This file is not the source of truth for GKE device plugins. Modifying this file would have no effect on GKE clusters.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -54,11 +55,6 @@ spec:
         ports:
         - name: "metrics"
           containerPort: 2112
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
         resources:

--- a/cmd/nvidia_gpu/device-plugin.yaml
+++ b/cmd/nvidia_gpu/device-plugin.yaml
@@ -55,6 +55,7 @@ spec:
         ports:
         - name: "metrics"
           containerPort: 2112
+        env:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
         resources:

--- a/cmd/nvidia_gpu/device-plugin.yaml
+++ b/cmd/nvidia_gpu/device-plugin.yaml
@@ -1,4 +1,3 @@
-# NOTE: This file is not the source of truth for GKE device plugins. Modifying this file would have no effect on GKE clusters.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -56,6 +55,10 @@ spec:
         - name: "metrics"
           containerPort: 2112
         env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
         resources:

--- a/pkg/gpu/nvidia/metrics/devices.go
+++ b/pkg/gpu/nvidia/metrics/devices.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml"
 
-	"github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/timesharing"
+	"github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/gpusharing"
 	"github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/util"
 
 	"github.com/golang/glog"
@@ -89,7 +89,7 @@ func GetDevicesForAllContainers() (map[ContainerID][]string, error) {
 				}
 				containerDevices[container] = make([]string, 0)
 				for _, deviceID := range d.DeviceIds {
-					if timesharing.IsVirtualDeviceID(deviceID) {
+					if gpusharing.IsVirtualDeviceID(deviceID) {
 						continue
 					}
 					containerDevices[container] = append(containerDevices[container], deviceID)

--- a/pkg/gpu/nvidia/metrics/devices.go
+++ b/pkg/gpu/nvidia/metrics/devices.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml"
 
-	"github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/gpusharing"
+	"github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/timesharing"
 	"github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/util"
 
 	"github.com/golang/glog"
@@ -89,7 +89,7 @@ func GetDevicesForAllContainers() (map[ContainerID][]string, error) {
 				}
 				containerDevices[container] = make([]string, 0)
 				for _, deviceID := range d.DeviceIds {
-					if gpusharing.IsVirtualDeviceID(deviceID) {
+					if timesharing.IsVirtualDeviceID(deviceID) {
 						continue
 					}
 					containerDevices[container] = append(containerDevices[container], deviceID)
@@ -99,6 +99,10 @@ func GetDevicesForAllContainers() (map[ContainerID][]string, error) {
 	}
 
 	return containerDevices, nil
+}
+
+func GetAllGpuDevices() map[string]*nvml.Device {
+	return gpuDevices
 }
 
 // DiscoverGPUDevices discovers GPUs attached to the node, and updates `gpuDevices` map.

--- a/pkg/gpu/nvidia/metrics/metrics.go
+++ b/pkg/gpu/nvidia/metrics/metrics.go
@@ -86,7 +86,7 @@ var (
 		},
 		[]string{"namespace", "pod", "container", "make", "accelerator_id", "model"})
 
-	// MemoryTotal reports the total memory available on the GPUper container.
+	// MemoryTotal reports the total memory available on the GPU per container.
 	MemoryTotal = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "memory_total",

--- a/pkg/gpu/nvidia/metrics/metrics_test.go
+++ b/pkg/gpu/nvidia/metrics/metrics_test.go
@@ -137,6 +137,7 @@ var (
 func TestMetricsUpdate(t *testing.T) {
 	gmc = &mockCollector{}
 	ms := MetricServer{}
+	t.Setenv("NODE_NAME", "node1")
 	ms.updateMetrics(containerDevicesMock, gpuDevicesMock)
 
 	if testutil.ToFloat64(
@@ -185,47 +186,47 @@ func TestMetricsUpdate(t *testing.T) {
 	}
 
 	if testutil.ToFloat64(
-		DutyCycleGpu.WithLabelValues(
-			"nvidia", "656547758", "model1")) != 78 ||
+		DutyCycleNodeGpu.WithLabelValues(
+			"node1", "nvidia", "656547758", "model1")) != 78 ||
 		testutil.ToFloat64(
-			DutyCycleGpu.WithLabelValues(
-				"nvidia", "850729563", "model2")) != 32 ||
+			DutyCycleNodeGpu.WithLabelValues(
+				"node1", "nvidia", "850729563", "model2")) != 32 ||
 		testutil.ToFloat64(
-			DutyCycleGpu.WithLabelValues(
-				"nvidia", "3572375710", "model1")) != 13 ||
+			DutyCycleNodeGpu.WithLabelValues(
+				"node1", "nvidia", "3572375710", "model1")) != 13 ||
 		testutil.ToFloat64(
-			DutyCycleGpu.WithLabelValues(
-				"nvidia", "8732906554", "model1")) != 1 {
-		t.Fatalf("Wrong Result in DutyCycleGpu")
+			DutyCycleNodeGpu.WithLabelValues(
+				"node1", "nvidia", "8732906554", "model1")) != 1 {
+		t.Fatalf("Wrong Result in DutyCycleNodeGpu")
 	}
 
 	if testutil.ToFloat64(
-		MemoryTotalGpu.WithLabelValues(
-			"nvidia", "656547758", "model1")) != 200*1024*1024 ||
+		MemoryTotalNodeGpu.WithLabelValues(
+			"node1", "nvidia", "656547758", "model1")) != 200*1024*1024 ||
 		testutil.ToFloat64(
-			MemoryTotalGpu.WithLabelValues(
-				"nvidia", "850729563", "model2")) != 200*1024*1024 ||
+			MemoryTotalNodeGpu.WithLabelValues(
+				"node1", "nvidia", "850729563", "model2")) != 200*1024*1024 ||
 		testutil.ToFloat64(
-			MemoryTotalGpu.WithLabelValues(
-				"nvidia", "3572375710", "model1")) != 350*1024*1024 ||
+			MemoryTotalNodeGpu.WithLabelValues(
+				"node1", "nvidia", "3572375710", "model1")) != 350*1024*1024 ||
 		testutil.ToFloat64(
-			MemoryTotalGpu.WithLabelValues(
-				"nvidia", "8732906554", "model1")) != 700*1024*1024 {
-		t.Fatalf("Wrong Result in MemoryTotalGpu")
+			MemoryTotalNodeGpu.WithLabelValues(
+				"node1", "nvidia", "8732906554", "model1")) != 700*1024*1024 {
+		t.Fatalf("Wrong Result in MemoryTotalNodeGpu")
 	}
 
 	if testutil.ToFloat64(
-		MemoryUsedGpu.WithLabelValues(
-			"nvidia", "656547758", "model1")) != 50*1024*1024 ||
+		MemoryUsedNodeGpu.WithLabelValues(
+			"node1", "nvidia", "656547758", "model1")) != 50*1024*1024 ||
 		testutil.ToFloat64(
-			MemoryUsedGpu.WithLabelValues(
-				"nvidia", "850729563", "model2")) != 150*1024*1024 ||
+			MemoryUsedNodeGpu.WithLabelValues(
+				"node1", "nvidia", "850729563", "model2")) != 150*1024*1024 ||
 		testutil.ToFloat64(
-			MemoryUsedGpu.WithLabelValues(
-				"nvidia", "3572375710", "model1")) != 100*1024*1024 ||
+			MemoryUsedNodeGpu.WithLabelValues(
+				"node1", "nvidia", "3572375710", "model1")) != 100*1024*1024 ||
 		testutil.ToFloat64(
-			MemoryUsedGpu.WithLabelValues(
-				"nvidia", "8732906554", "model1")) != 375*1024*1024 {
-		t.Fatalf("Wrong Result in MemoryUsedGpu")
+			MemoryUsedNodeGpu.WithLabelValues(
+				"node1", "nvidia", "8732906554", "model1")) != 375*1024*1024 {
+		t.Fatalf("Wrong Result in MemoryUsedNodeGpu")
 	}
 }


### PR DESCRIPTION
Summary of changes:

- Export per GPU metrics for the node.
- Metrics exported are per node instead of per container or pod
- Node name is passed through by an environment variable

Tested via:
$ kubectl --namespace=kube-system port-forward nvidia-gpu-device-plugin-test-fkfw5  2112:2112
$ curl http://127.0.0.1:2112/metrics | grep GPU-
duty_cycle{accelerator_id="GPU-5cbb3167-74b9-b175-75d8-1a79110649f7",container="my-gpu-container",make="nvidia",model="Tesla T4",namespace="default",pod="my-gpu-pod-test-0"} 65
  
duty_cycle_gpu{accelerator_id="GPU-5cbb3167-74b9-b175-75d8-1a79110649f7",make="nvidia",model="Tesla T4",node_name="gke-yashks-cluster-default-pool-bbe26b4d-r0kj"} 64

memory_total{accelerator_id="GPU-5cbb3167-74b9-b175-75d8-1a79110649f7",container="my-gpu-container",make="nvidia",model="Tesla T4",namespace="default",pod="my-gpu-pod-test-0"} 1.5842934784e+10

memory_total_gpu{accelerator_id="GPU-5cbb3167-74b9-b175-75d8-1a79110649f7",make="nvidia",model="Tesla T4",node_name="gke-yashks-cluster-default-pool-bbe26b4d-r0kj"} 1.5842934784e+10

memory_used{accelerator_id="GPU-5cbb3167-74b9-b175-75d8-1a79110649f7",container="my-gpu-container",make="nvidia",model="Tesla T4",namespace="default",pod="my-gpu-pod-test-0"} 1.9922944e+08

memory_used_gpu{accelerator_id="GPU-5cbb3167-74b9-b175-75d8-1a79110649f7",make="nvidia",model="Tesla T4",node_name="gke-yashks-cluster-default-pool-bbe26b4d-r0kj"} 1.9922944e+08

