### PR TITLE
update the base image to bullseye-v1.4.2-gke.4

### DIFF
--- a/fast-socket-installer/image/Dockerfile
+++ b/fast-socket-installer/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/gke-release/debian-base:bullseye-v1.4.2-gke.3
+FROM gcr.io/gke-release/debian-base:bullseye-v1.4.2-gke.4
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends --allow-change-held-packages apt-transport-https ca-certificates curl gnupg && \


### PR DESCRIPTION
Update the NCCL base image to bullseye-v1.4.2-gke.4, based on the security team request