### PR TITLE
Add system-node-critical priority to driver installer

### DIFF
--- a/nvidia-driver-installer/cos/daemonset-nvidia-mig.yaml
+++ b/nvidia-driver-installer/cos/daemonset-nvidia-mig.yaml
@@ -35,6 +35,7 @@ spec:
         name: nvidia-driver-installer
         k8s-app: nvidia-driver-installer
     spec:
+      priorityClassName: system-node-critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
@@ -39,6 +39,7 @@ spec:
         name: nvidia-driver-installer
         k8s-app: nvidia-driver-installer
     spec:
+      priorityClassName: system-node-critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded.yaml
@@ -39,6 +39,7 @@ spec:
         name: nvidia-driver-installer
         k8s-app: nvidia-driver-installer
     spec:
+      priorityClassName: system-node-critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/nvidia-driver-installer/ubuntu/daemonset-preloaded.yaml
+++ b/nvidia-driver-installer/ubuntu/daemonset-preloaded.yaml
@@ -31,6 +31,7 @@ spec:
         name: nvidia-driver-installer
         k8s-app: nvidia-driver-installer
     spec:
+      priorityClassName: system-node-critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/nvidia-driver-installer/ubuntu/daemonset.yaml
+++ b/nvidia-driver-installer/ubuntu/daemonset.yaml
@@ -31,6 +31,7 @@ spec:
         name: nvidia-driver-installer
         k8s-app: nvidia-driver-installer
     spec:
+      priorityClassName: system-node-critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
To prevent starvation from other pods that might depend on the driver.

Tested:
On GKE v1.22.12-gke.2300