### PR TITLE
Combine the installer for normal GPU and MIG GPU

### DIFF
--- a/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
@@ -102,7 +102,27 @@ spec:
           mountPath: /root
         - name: cos-tools
           mountPath: /build/cos-tools
+        - name: nvidia-config
+          hostPath:
+            path: /etc/nvidia
         command: ['/cos-gpu-installer', 'install', '--version=latest']
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:c54fd003948fac687c2a93a55ea6e4d47ffbd641278a9191e75e822fe72471c2"
+        name: partition-gpus
+        env:
+          - name: LD_LIBRARY_PATH
+            value: /usr/local/nvidia/lib64
+        resources:
+          requests:
+            cpu: "0.15"
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: nvidia-install-dir-host
+            mountPath: /usr/local/nvidia
+          - name: dev
+            mountPath: /dev
+          - name: nvidia-config
+            mountPath: /etc/nvidia
       containers:
       - image: "gcr.io/google-containers/pause:2.0"
         name: pause

--- a/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded.yaml
@@ -67,6 +67,9 @@ spec:
       - name: cos-tools
         hostPath:
           path: /var/lib/cos-tools
+      - name: nvidia-config
+        hostPath:
+          path: /etc/nvidia
       initContainers:
       - image: "cos-nvidia-installer:fixed"
         imagePullPolicy: Never
@@ -102,6 +105,23 @@ spec:
           mountPath: /root
         - name: cos-tools
           mountPath: /build/cos-tools
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:c54fd003948fac687c2a93a55ea6e4d47ffbd641278a9191e75e822fe72471c2"
+        name: partition-gpus
+        env:
+          - name: LD_LIBRARY_PATH
+            value: /usr/local/nvidia/lib64
+        resources:
+          requests:
+            cpu: "0.15"
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: nvidia-install-dir-host
+            mountPath: /usr/local/nvidia
+          - name: dev
+            mountPath: /dev
+          - name: nvidia-config
+            mountPath: /etc/nvidia
       containers:
       - image: "gcr.io/google-containers/pause:2.0"
         name: pause


### PR DESCRIPTION
Combine the installer for normal GPU and MIG GPU. The additional init container for MIG (partition-gpus) will be skipped when the installer is running in the normal GPU. There is no increasing installer latency detected for normal GPU with this change.