### PR TITLE
#265 moved misplaced volume spec to within volumes

### DIFF
--- a/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
@@ -67,6 +67,9 @@ spec:
       - name: cos-tools
         hostPath:
           path: /var/lib/cos-tools
+      - name: nvidia-config
+        hostPath:
+          path: /etc/nvidia
       initContainers:
       - image: "cos-nvidia-installer:fixed"
         imagePullPolicy: Never
@@ -102,9 +105,6 @@ spec:
           mountPath: /root
         - name: cos-tools
           mountPath: /build/cos-tools
-        - name: nvidia-config
-          hostPath:
-            path: /etc/nvidia
         command: ['/cos-gpu-installer', 'install', '--version=latest']
       - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:c54fd003948fac687c2a93a55ea6e4d47ffbd641278a9191e75e822fe72471c2"
         name: partition-gpus


### PR DESCRIPTION
It looks like someone just put a volume spec in the wrong place.  This matches the yaml configuration of the not "-latest" version which does work as expected.