### PR TITLE
Combine MIG and non-MIG to use the same driver installer yaml file.

### DIFF
--- a/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
@@ -67,6 +67,9 @@ spec:
       - name: cos-tools
         hostPath:
           path: /var/lib/cos-tools
+      - name: nvidia-config
+        hostPath:
+          path: /etc/nvidia
       initContainers:
       - image: "cos-nvidia-installer:fixed"
         imagePullPolicy: Never
@@ -103,6 +106,23 @@ spec:
         - name: cos-tools
           mountPath: /build/cos-tools
         command: ['/cos-gpu-installer', 'install', '--version=latest']
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:c54fd003948fac687c2a93a55ea6e4d47ffbd641278a9191e75e822fe72471c2"
+        name: partition-gpus
+        env:
+          - name: LD_LIBRARY_PATH
+            value: /usr/local/nvidia/lib64
+        resources:
+          requests:
+            cpu: "0.15"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: nvidia-install-dir-host
+          mountPath: /usr/local/nvidia
+        - name: dev
+          mountPath: /dev
+        - name: nvidia-config
+          mountPath: /etc/nvidia
       containers:
       - image: "gcr.io/google-containers/pause:2.0"
         name: pause

--- a/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded.yaml
@@ -67,6 +67,9 @@ spec:
       - name: cos-tools
         hostPath:
           path: /var/lib/cos-tools
+      - name: nvidia-config
+        hostPath:
+          path: /etc/nvidia
       initContainers:
       - image: "cos-nvidia-installer:fixed"
         imagePullPolicy: Never
@@ -102,6 +105,23 @@ spec:
           mountPath: /root
         - name: cos-tools
           mountPath: /build/cos-tools
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:c54fd003948fac687c2a93a55ea6e4d47ffbd641278a9191e75e822fe72471c2"
+        name: partition-gpus
+        env:
+          - name: LD_LIBRARY_PATH
+            value: /usr/local/nvidia/lib64
+        resources:
+          requests:
+            cpu: "0.15"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: nvidia-install-dir-host
+          mountPath: /usr/local/nvidia
+        - name: dev
+          mountPath: /dev
+        - name: nvidia-config
+          mountPath: /etc/nvidia
       containers:
       - image: "gcr.io/google-containers/pause:2.0"
         name: pause


### PR DESCRIPTION
Tested with the following cases:
1. v100
2. v100 with sharing strategy
3. a100 without MIG
4. a100 with sharing strategy and without MIG 

Signed-off-by: grac3gao <gracegao@google.com>