### PR TITLE
Migrate podresources API from v1alpha to v1

### DIFF
--- a/pkg/gpu/nvidia/metrics/devices.go
+++ b/pkg/gpu/nvidia/metrics/devices.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/golang/glog"
 	"google.golang.org/grpc"
-	podresources "k8s.io/kubernetes/pkg/kubelet/apis/podresources/v1alpha1"
+	podresources "k8s.io/kubernetes/pkg/kubelet/apis/podresources/v1"
 )
 
 var (


### PR DESCRIPTION
Migrate podresources API from v1alpha to v1