### PR TITLE
Add node affinity requirement for cloud.google.com/gke-os-distribution

### DIFF
--- a/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
@@ -49,6 +49,10 @@ spec:
                 operator: Exists
               - key: cloud.google.com/gke-gpu-driver-version
                 operator: DoesNotExist
+              - key: cloud.google.com/gke-os-distribution
+                operator: In
+                values:
+                - cos
       tolerations:
       - operator: "Exists"
       hostNetwork: true

--- a/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded.yaml
@@ -49,6 +49,10 @@ spec:
                 operator: Exists
               - key: cloud.google.com/gke-gpu-driver-version
                 operator: DoesNotExist
+              - key: cloud.google.com/gke-os-distribution
+                operator: In
+                values:
+                - cos
       tolerations:
       - operator: "Exists"
       hostNetwork: true

--- a/nvidia-driver-installer/ubuntu/daemonset-preloaded.yaml
+++ b/nvidia-driver-installer/ubuntu/daemonset-preloaded.yaml
@@ -41,6 +41,10 @@ spec:
                 operator: Exists
               - key: cloud.google.com/gke-gpu-driver-version
                 operator: DoesNotExist
+              - key: cloud.google.com/gke-os-distribution
+                operator: In
+                values:
+                - ubuntu
       tolerations:
       - operator: "Exists"
       volumes:

--- a/nvidia-driver-installer/ubuntu/daemonset.yaml
+++ b/nvidia-driver-installer/ubuntu/daemonset.yaml
@@ -39,6 +39,10 @@ spec:
             - matchExpressions:
               - key: cloud.google.com/gke-accelerator
                 operator: Exists
+              - key: cloud.google.com/gke-os-distribution
+                operator: In
+                values:
+                - ubuntu
       tolerations:
       - operator: "Exists"
       volumes:


### PR DESCRIPTION
Ensures that these daemonsets don't attempt to schedule on nodes for which they aren't intended.