### PR TITLE
Update golang base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19 as builder
+FROM golang:1.19-bullseye as builder
 WORKDIR /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators
 COPY . .
 RUN go build cmd/nvidia_gpu/nvidia_gpu.go

--- a/partition_gpu/Dockerfile
+++ b/partition_gpu/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19 as builder
+FROM golang:1.19-bullseye as builder
 WORKDIR /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators
 COPY . .
 RUN go build -o gpu_partitioner partition_gpu/partition_gpu.go


### PR DESCRIPTION
Fix `version GLIBC_2.32 not found (required by /usr/bin/nvidia-gpu-device-plugin)` error. Partition gpu image was manually tested on A100 40GB GPU with partition size 1g5gb