### PR TITLE
Create Dependabot Configuation to support Docker and go module updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: /nvidia-driver-installer/ubuntu
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /nvidia-driver-installer/minikube
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /partition_gpu
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /fast-socket-installer/image
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /vendor/golang.org/x/net/http2
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /demo/gpu-error/illegal-memory-access
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: weekly
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  groups:
+    gomod-dependencies:
+      patterns:
+      - '*'


### PR DESCRIPTION

Enable Dependabot for Dockerfile and go.mod updates.
This will update images in Dockerfile `FROM` statements, and go modules.

This PR is created by a script. Please let me know if we should modify any values.
