### PR TITLE
Configure Dependabot schedule and default reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,5 @@ updates:
   - grac3gao
   - Jiaqicao257
   - aston-github
+  - elfinhe 
+  - samuelkarp

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  labels:
+  - dependencies
+  - go
+  schedule:
+    interval: weekly
+    day: monday
+    time: "03:00"
+    timezone: America/Los_Angeles
+  target-branch: develop
+  reviewers:
+  - grac3gao
+  - Jiaqicao257
+  - aston-github


### PR DESCRIPTION
Add default reviewers to notify team of Dependabot pull requests. Based on dependabot.yml from Google Cloud Platform's hpc-toolkit repository: https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/e8a7e2031969e1335ee92c0983a078e0228c1763/.github/dependabot.yml