### PR TITLE
Add missing dependency for python3

### DIFF
--- a/nvidia-driver-installer/minikube/Dockerfile
+++ b/nvidia-driver-installer/minikube/Dockerfile
@@ -15,7 +15,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update && \
-    apt-get install -y kmod gcc make curl xz-utils libc6-dev bc libelf-dev bison flex openssl libssl-dev && \
+    apt-get install -y kmod gcc make curl xz-utils libc6-dev bc libelf-dev bison flex openssl libssl-dev python3 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
The nvidia-driver-installer addon for minikube is failing with these logs from the init container:

<details>
  <summary>Logs from the nvidia-driver-installer init container</summary>

    $ kubectl -n kube-system logs pod/nvidia-driver-installer-tcv94 -c nvidia-driver-installer
    
    + NVIDIA_DRIVER_VERSION=510.60.02
    + NVIDIA_DRIVER_DOWNLOAD_URL_DEFAULT=https://us.download.nvidia.com/XFree86/Linux-x86_64/510.60.02/NVIDIA-Linux-x86_64-510.60.02.run
    + NVIDIA_DRIVER_DOWNLOAD_URL=https://us.download.nvidia.com/XFree86/Linux-x86_64/510.60.02/NVIDIA-Linux-x86_64-510.60.02.run
    + NVIDIA_INSTALL_DIR_HOST=/home/kubernetes/bin/nvidia
    + NVIDIA_INSTALL_DIR_CONTAINER=/usr/local/nvidia
    ++ basename https://us.download.nvidia.com/XFree86/Linux-x86_64/510.60.02/NVIDIA-Linux-x86_64-510.60.02.run
    + NVIDIA_INSTALLER_RUNFILE=NVIDIA-Linux-x86_64-510.60.02.run
    + ROOT_MOUNT_DIR=/root
    + CACHE_FILE=/usr/local/nvidia/.cache
    ++ uname -r
    + KERNEL_VERSION=5.10.57
    ++ cut -d . -f 1
    +++ uname -r
    ++ echo 5.10.57
    + MAJOR_KERNEL_VERSION=5
    + set +x
    KERNEL_VERSION: 5.10.57
    Checking cached version
    Cache file /usr/local/nvidia/.cache not found.
    Downloading kernel sources...
    /usr/src /
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
    100  111M  100  111M    0     0  33.8M      0  0:00:03  0:00:03 --:--:-- 33.8M
    /
    Downloading kernel sources... DONE.
    Configuring installation directories...
    /usr/local/nvidia /
    Updating container's ld cache...
    Updating container's ld cache... DONE.
    /
    Configuring installation directories... DONE.
    Downloading Nvidia installer...
    /usr/local/nvidia /
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
    100  313M  100  313M    0     0  34.6M      0  0:00:09  0:00:09 --:--:-- 35.0M
    /
    Downloading Nvidia installer... DONE.
    Configuring kernel sources...
    /usr/src/linux-5.10.57 /
      HOSTCC  scripts/basic/fixdep
      HOSTCC  scripts/kconfig/conf.o
      HOSTCC  scripts/kconfig/confdata.o
      HOSTCC  scripts/kconfig/expr.o
      LEX     scripts/kconfig/lexer.lex.c
      YACC    scripts/kconfig/parser.tab.[ch]
      HOSTCC  scripts/kconfig/lexer.lex.o
      HOSTCC  scripts/kconfig/parser.tab.o
      HOSTCC  scripts/kconfig/preprocess.o
      HOSTCC  scripts/kconfig/symbol.o
      HOSTCC  scripts/kconfig/util.o
      HOSTLD  scripts/kconfig/conf
    #
    # configuration written to .config
    #
      SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
      SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
      SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
      SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
      SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
      SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
      SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
      HOSTCC  arch/x86/tools/relocs_32.o
      HOSTCC  arch/x86/tools/relocs_64.o
      HOSTCC  arch/x86/tools/relocs_common.o
      HOSTLD  arch/x86/tools/relocs
      HOSTCC  scripts/genksyms/genksyms.o
      YACC    scripts/genksyms/parse.tab.[ch]
      HOSTCC  scripts/genksyms/parse.tab.o
      LEX     scripts/genksyms/lex.lex.c
      HOSTCC  scripts/genksyms/lex.lex.o
      HOSTLD  scripts/genksyms/genksyms
      HOSTCC  scripts/selinux/genheaders/genheaders
      HOSTCC  scripts/selinux/mdp/mdp
      HOSTCC  scripts/kallsyms
      HOSTCC  scripts/recordmcount
      HOSTCC  scripts/sorttable
      HOSTCC  scripts/asn1_compiler
      HOSTCC  scripts/extract-cert
      WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
      WRAP    arch/x86/include/generated/uapi/asm/errno.h
      WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
      WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
      WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
      WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
      WRAP    arch/x86/include/generated/uapi/asm/param.h
      WRAP    arch/x86/include/generated/uapi/asm/poll.h
      WRAP    arch/x86/include/generated/uapi/asm/resource.h
      WRAP    arch/x86/include/generated/uapi/asm/socket.h
      WRAP    arch/x86/include/generated/uapi/asm/sockios.h
      WRAP    arch/x86/include/generated/uapi/asm/termbits.h
      WRAP    arch/x86/include/generated/uapi/asm/termios.h
      WRAP    arch/x86/include/generated/uapi/asm/types.h
      WRAP    arch/x86/include/generated/asm/early_ioremap.h
      WRAP    arch/x86/include/generated/asm/export.h
      WRAP    arch/x86/include/generated/asm/mcs_spinlock.h
      WRAP    arch/x86/include/generated/asm/irq_regs.h
      WRAP    arch/x86/include/generated/asm/local64.h
      WRAP    arch/x86/include/generated/asm/mm-arch-hooks.h
      WRAP    arch/x86/include/generated/asm/mmiowb.h
      WRAP    arch/x86/include/generated/asm/module.lds.h
      WRAP    arch/x86/include/generated/asm/rwonce.h
      UPD     include/config/kernel.release
      UPD     include/generated/uapi/linux/version.h
      UPD     include/generated/utsrelease.h
      CC      scripts/mod/empty.o
      HOSTCC  scripts/mod/mk_elfconfig
      MKELF   scripts/mod/elfconfig.h
      HOSTCC  scripts/mod/modpost.o
      CC      scripts/mod/devicetable-offsets.s
      UPD     scripts/mod/devicetable-offsets.h
      HOSTCC  scripts/mod/file2alias.o
      HOSTCC  scripts/mod/sumversion.o
      HOSTLD  scripts/mod/modpost
      CC      kernel/bounds.s
      UPD     include/generated/bounds.h
      UPD     include/generated/timeconst.h
      CC      arch/x86/kernel/asm-offsets.s
      UPD     include/generated/asm-offsets.h
      CALL    scripts/checksyscalls.sh
      CALL    scripts/atomic/check-atomics.sh
      DESCEND  objtool
      HOSTCC   /usr/src/linux-5.10.57/tools/objtool/fixdep.o
      HOSTLD   /usr/src/linux-5.10.57/tools/objtool/fixdep-in.o
      LINK     /usr/src/linux-5.10.57/tools/objtool/fixdep
      CC       /usr/src/linux-5.10.57/tools/objtool/exec-cmd.o
      CC       /usr/src/linux-5.10.57/tools/objtool/help.o
      CC       /usr/src/linux-5.10.57/tools/objtool/pager.o
      CC       /usr/src/linux-5.10.57/tools/objtool/parse-options.o
      CC       /usr/src/linux-5.10.57/tools/objtool/run-command.o
      CC       /usr/src/linux-5.10.57/tools/objtool/sigchain.o
      CC       /usr/src/linux-5.10.57/tools/objtool/subcmd-config.o
      LD       /usr/src/linux-5.10.57/tools/objtool/libsubcmd-in.o
      AR       /usr/src/linux-5.10.57/tools/objtool/libsubcmd.a
      CC       /usr/src/linux-5.10.57/tools/objtool/arch/x86/special.o
      MKDIR    /usr/src/linux-5.10.57/tools/objtool/arch/x86/lib/
      GEN      /usr/src/linux-5.10.57/tools/objtool/arch/x86/lib/inat-tables.c
      CC       /usr/src/linux-5.10.57/tools/objtool/arch/x86/decode.o
      LD       /usr/src/linux-5.10.57/tools/objtool/arch/x86/objtool-in.o
      CC       /usr/src/linux-5.10.57/tools/objtool/weak.o
      CC       /usr/src/linux-5.10.57/tools/objtool/check.o
      CC       /usr/src/linux-5.10.57/tools/objtool/special.o
      CC       /usr/src/linux-5.10.57/tools/objtool/orc_gen.o
      CC       /usr/src/linux-5.10.57/tools/objtool/orc_dump.o
      CC       /usr/src/linux-5.10.57/tools/objtool/builtin-check.o
      CC       /usr/src/linux-5.10.57/tools/objtool/builtin-orc.o
      CC       /usr/src/linux-5.10.57/tools/objtool/elf.o
      CC       /usr/src/linux-5.10.57/tools/objtool/objtool.o
      CC       /usr/src/linux-5.10.57/tools/objtool/libstring.o
      CC       /usr/src/linux-5.10.57/tools/objtool/libctype.o
      CC       /usr/src/linux-5.10.57/tools/objtool/str_error_r.o
      CC       /usr/src/linux-5.10.57/tools/objtool/librbtree.o
      LD       /usr/src/linux-5.10.57/tools/objtool/objtool-in.o
      LINK     /usr/src/linux-5.10.57/tools/objtool/objtool
      DESCEND  bpf/resolve_btfids
      MKDIR     /usr/src/linux-5.10.57/tools/bpf/resolve_btfids//libbpf
    
    Auto-detecting system features:
    ...                        libelf: [ on  ]
    ...                          zlib: [ on  ]
    ...                           bpf: [ on  ]
    
      GEN      /usr/src/linux-5.10.57/tools/bpf/resolve_btfids/libbpf/bpf_helper_defs.h
    /usr/bin/env: 'python3': No such file or directory
    Makefile:182: recipe for target '/usr/src/linux-5.10.57/tools/bpf/resolve_btfids/libbpf/bpf_helper_defs.h' failed
    make[3]: *** [/usr/src/linux-5.10.57/tools/bpf/resolve_btfids/libbpf/bpf_helper_defs.h] Error 127
    make[3]: *** Deleting file '/usr/src/linux-5.10.57/tools/bpf/resolve_btfids/libbpf/bpf_helper_defs.h'
    make[2]: *** [/usr/src/linux-5.10.57/tools/bpf/resolve_btfids//libbpf/libbpf.a] Error 2
    Makefile:44: recipe for target '/usr/src/linux-5.10.57/tools/bpf/resolve_btfids//libbpf/libbpf.a' failed
    make[1]: *** [bpf/resolve_btfids] Error 2
    Makefile:71: recipe for target 'bpf/resolve_btfids' failed
    Makefile:1947: recipe for target 'tools/bpf/resolve_btfids' failed
    make: *** [tools/bpf/resolve_btfids] Error 2
</details>

The error is `/usr/bin/env: 'python3': No such file or directory`.
Fixed with this one line Pull Request.

Cheers