### PR TITLE
Upgrade nvml version to be compatible with golang:1.22-bullseye

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleCloudPlatform/container-engine-accelerators
 go 1.19
 
 require (
-	github.com/NVIDIA/go-nvml v0.12.0-1
+	github.com/NVIDIA/go-nvml v0.12.0-2
 	github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20211102125545-5a2c58442e48
 	github.com/containerd/nri v0.5.0
 	github.com/golang/glog v1.1.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/NVIDIA/go-nvml v0.12.0-1
+# github.com/NVIDIA/go-nvml v0.12.0-2
 ## explicit; go 1.15
 github.com/NVIDIA/go-nvml/pkg/dl
 github.com/NVIDIA/go-nvml/pkg/nvml


### PR DESCRIPTION
Follow up to Golang upgrade from golang:1.20-bullseye to golang:1.22-bullseye. Go upgrade causes nvml functions to fail due to segmentation fault. Community discussion can be found here: https://github.com/NVIDIA/go-nvml/issues/36. Latest nvml version should fix this bug, like what was done in https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/commit/64c577a32c9d4b33941c4273b853502db36c1bd7