### PR TITLE
Update nvidia-driver-installer pull policy for init container

### DIFF
--- a/nvidia-driver-installer/cos/daemonset-nvidia-mig.yaml
+++ b/nvidia-driver-installer/cos/daemonset-nvidia-mig.yaml
@@ -68,7 +68,6 @@ spec:
           path: /etc/nvidia
       initContainers:
       - image: "cos-nvidia-installer:fixed"
-        imagePullPolicy: Never
         name: nvidia-driver-installer
         resources:
           requests:

--- a/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
@@ -74,7 +74,6 @@ spec:
           path: /etc/nvidia
       initContainers:
       - image: "cos-nvidia-installer:fixed"
-        imagePullPolicy: Never
         name: nvidia-driver-installer
         resources:
           requests:

--- a/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded.yaml
@@ -74,7 +74,6 @@ spec:
           path: /etc/nvidia
       initContainers:
       - image: "cos-nvidia-installer:fixed"
-        imagePullPolicy: Never
         name: nvidia-driver-installer
         resources:
           requests:


### PR DESCRIPTION
I've run into an issue where node maintenance on GPU nodes prevents this daemonset from starting up again. Specifically, our issue looks like this:

1. GCP schedules maintenance for our node (we cannot prevent this)--we’re using the termination maintenance policy [here](https://cloud.google.com/compute/docs/instances/host-maintenance-overview#terminate_and_optionally_restart), so the node gets stopped.
2. Node gets restarted, and GCP tries attaching the local SSD’s from before but cannot. These local SSD’s are used for containerd image storage via a symlink and also Nvidia driver storage. So these means that all the images will be wiped from the node.
3. The daemonset which exposes GPU’s on the node cannot start, since the image doesn’t exist and the pull policy is set to ‘Never’

The fix here entails self-managing a modified version of the daemonset that has the adjusted pull policy. The documentation should link to a daemonset that's able to work properly after node maintenance events.