### PR TITLE
Revert "Update nccl-test.yaml"

### DIFF
--- a/gpudirect-tcpxo/nccl-test.yaml
+++ b/gpudirect-tcpxo/nccl-test.yaml
@@ -37,7 +37,7 @@ spec:
         - |
           set -ex
           chmod 755 /fts/entrypoint_rxdm_container.sh
-          /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=8 --uid= --alsologtostderr --enforce_kernel_ipv6_support=false
+          /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=8 --uid= --alsologtostderr
       securityContext:
         privileged: true
       volumeMounts:


### PR DESCRIPTION
Reverts GoogleCloudPlatform/container-engine-accelerators#379

Previously thought this was needed even with hostNetwork:True set but reconfirmed this is not the case as long as those values are set correct.