### PR TITLE
Update label-nodes-daemon.yaml

### DIFF
--- a/gpudirect-tcpxo/topology-scheduler/label-nodes-daemon.yaml
+++ b/gpudirect-tcpxo/topology-scheduler/label-nodes-daemon.yaml
@@ -15,6 +15,8 @@ spec:
       tolerations:
       - operator: "Exists"
         key: nvidia.com/gpu
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: label-nodes-daemon
           image: python:3.9


### PR DESCRIPTION
Adding hostNetwork: true until workload identity can support the attributes data as expected: https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity#instance_attributes