### PR TITLE
Update label-nodes-daemon.yaml

### DIFF
--- a/gpudirect-tcpxo/topology-scheduler/label-nodes-daemon.yaml
+++ b/gpudirect-tcpxo/topology-scheduler/label-nodes-daemon.yaml
@@ -15,6 +15,7 @@ spec:
       tolerations:
       - operator: "Exists"
         key: nvidia.com/gpu
+      hostNetwork: true
       containers:
         - name: label-nodes-daemon
           image: python:3.9


### PR DESCRIPTION
Added hostNetwork until workload identity can support this attribute for physical_host: https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity#metadata_server