### PR TITLE
Fix two bug related to metrics

### DIFF
--- a/cmd/nvidia_gpu/nvidia_gpu.go
+++ b/cmd/nvidia_gpu/nvidia_gpu.go
@@ -124,14 +124,18 @@ func main() {
 	}
 
 	if *enableContainerGPUMetrics {
-		glog.Infof("Starting metrics server on port: %d, endpoint path: %s, collection frequency: %d", *gpuMetricsPort, "/metrics", *gpuMetricsCollectionIntervalMs)
-		metricServer := metrics.NewMetricServer(*gpuMetricsCollectionIntervalMs, *gpuMetricsPort, "/metrics")
-		err := metricServer.Start()
-		if err != nil {
-			glog.Infof("Failed to start metric server: %v", err)
-			return
+		if gpuConfig.GPUPartitionSize != "" {
+			glog.Info("Using multi-instance GPU, metrics are not supported.")
+		} else {
+			glog.Infof("Starting metrics server on port: %d, endpoint path: %s, collection frequency: %d", *gpuMetricsPort, "/metrics", *gpuMetricsCollectionIntervalMs)
+			metricServer := metrics.NewMetricServer(*gpuMetricsCollectionIntervalMs, *gpuMetricsPort, "/metrics")
+			err := metricServer.Start()
+			if err != nil {
+				glog.Infof("Failed to start metric server: %v", err)
+				return
+			}
+			defer metricServer.Stop()
 		}
-		defer metricServer.Stop()
 	}
 
 	if *enableHealthMonitoring {

--- a/pkg/gpu/nvidia/metrics/devices.go
+++ b/pkg/gpu/nvidia/metrics/devices.go
@@ -85,13 +85,14 @@ func GetDevicesForAllContainers() (map[ContainerID][]string, error) {
 				if len(d.DeviceIds) == 0 || d.ResourceName != gpuResourceName {
 					continue
 				}
-				containerDevices[container] = make([]string, 0)
+				var devices []string
 				for _, deviceID := range d.DeviceIds {
 					if gpusharing.IsVirtualDeviceID(deviceID) {
 						continue
 					}
-					containerDevices[container] = append(containerDevices[container], deviceID)
+					devices = append(devices, deviceID)
 				}
+				containerDevices[container] = append(containerDevices[container], devices...)
 			}
 		}
 	}


### PR DESCRIPTION
Fix two bug related to metrics
1. MIG GPU doesn't support metrics, should skip
2. When container has multiple GPUs, during one round of the metrics collection, only one GPU's metrics is collected. Should expose metrics for all GPUs.