### PR TITLE
Remove grpcServer.Stop() when stream.Send() fails on ListAndWatch

### DIFF
--- a/pkg/gpu/nvidia/beta_plugin.go
+++ b/pkg/gpu/nvidia/beta_plugin.go
@@ -138,7 +138,6 @@ func (s *pluginServiceV1Beta1) sendDevices(stream pluginapi.DevicePlugin_ListAnd
 	glog.Infof("ListAndWatch: send devices %v\n", resp)
 	if err := stream.Send(resp); err != nil {
 		glog.Errorf("device-plugin: cannot update device states: %v\n", err)
-		s.ngm.grpcServer.Stop()
 		return err
 	}
 	return nil


### PR DESCRIPTION
The error handling of failures to stream.Send(resp) during ListAndWatch is not completely reliable.

Take for instance, if stream.Send() fails and kubelet never restarts, then stopping the grpcServer will mean device plugin will never reconnect with kubelet because the socket will still exist in `/var/lib/kubelet/device-plugins/` and therefore device plugin will not trigger itself to re-register with kubelet and the grpc server is never started again.

the grpcServer is only created during registeration so in this case we will be stuck in a state where the grpcServer is stopped with no way of starting it again. This will put Device Plugins in an unrecoverable state. 

Instead we should not stop the grpcServer on failure of send and continue with ListAndWatch logic and retry send on the next device health update.