### PR TITLE
Add tcpxo daemon anti affinity to avoid duplicate scheduling

### DIFF
--- a/gpudirect-tcpxo/nccl-test-latest-autopilot.yaml
+++ b/gpudirect-tcpxo/nccl-test-latest-autopilot.yaml
@@ -22,6 +22,7 @@ metadata:
   name: nccl-test-host-1
   labels:
     name: nccl-host-1
+    tcpxo: daemon
   annotations:
     devices.gke.io/container.tcpxo-daemon: |+
       - path: /dev/nvidia0
@@ -49,6 +50,16 @@ metadata:
         {"interfaceName":"eth8","network":"vpc8"}
       ]
 spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: tcpxo
+            operator: In
+            values:
+            - daemon
+        topologyKey: "kubernetes.io/hostname"
   nodeSelector:
     cloud.google.com/gke-accelerator: nvidia-h100-mega-80gb
     cloud.google.com/gke-spot: "true"
@@ -132,6 +143,7 @@ metadata:
   name: nccl-test-host-2
   labels:
     name: nccl-host-2
+    tcpxo: daemon
   annotations:
     devices.gke.io/container.tcpxo-daemon: |+
       - path: /dev/nvidia0
@@ -159,6 +171,16 @@ metadata:
         {"interfaceName":"eth8","network":"vpc8"}
       ]
 spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: tcpxo
+            operator: In
+            values:
+            - daemon
+        topologyKey: "kubernetes.io/hostname"
   nodeSelector:
     cloud.google.com/gke-accelerator: nvidia-h100-mega-80gb
     cloud.google.com/gke-spot: "true"

--- a/gpudirect-tcpxo/nccl-test-latest.yaml
+++ b/gpudirect-tcpxo/nccl-test-latest.yaml
@@ -36,6 +36,7 @@ metadata:
   name: nccl-test-host-1
   labels:
     name: nccl-host-1
+    tcpxo: daemon
   annotations:
     devices.gke.io/container.tcpxo-daemon: |+
       - path: /dev/nvidia0
@@ -63,6 +64,16 @@ metadata:
         {"interfaceName":"eth8","network":"vpc8"}
       ]
 spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: tcpxo
+            operator: In
+            values:
+            - daemon
+        topologyKey: "kubernetes.io/hostname"
   hostname: host1
   subdomain: nccl-host-1
   #  hostNetwork: true
@@ -155,6 +166,7 @@ metadata:
   name: nccl-test-host-2
   labels:
     name: nccl-host-2
+    tcpxo: daemon
   annotations:
     devices.gke.io/container.tcpxo-daemon: |+
       - path: /dev/nvidia0
@@ -182,6 +194,16 @@ metadata:
         {"interfaceName":"eth8","network":"vpc8"}
       ]
 spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: tcpxo
+            operator: In
+            values:
+            - daemon
+        topologyKey: "kubernetes.io/hostname"
   hostname: host2
   subdomain: nccl-host-2
   #  hostNetwork: true

--- a/gpudirect-tcpxo/nccl-test-unprivileged-without-hostnetwork.yaml
+++ b/gpudirect-tcpxo/nccl-test-unprivileged-without-hostnetwork.yaml
@@ -22,6 +22,7 @@ metadata:
   name: nccl-test-host-1
   labels:
     name: nccl-host-1
+    tcpxo: daemon
   annotations:
     devices.gke.io/container.tcpxo-daemon: |+
       - path: /dev/nvidia0
@@ -49,6 +50,16 @@ metadata:
         {"interfaceName":"eth8","network":"vpc8"}
       ]
 spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: tcpxo
+            operator: In
+            values:
+            - daemon
+        topologyKey: "kubernetes.io/hostname"
   hostname: host1
   subdomain: nccl-host-1
   #  hostNetwork: true
@@ -141,6 +152,7 @@ metadata:
   name: nccl-test-host-2
   labels:
     name: nccl-host-2
+    tcpxo: daemon
   annotations:
     devices.gke.io/container.tcpxo-daemon: |+
       - path: /dev/nvidia0
@@ -168,6 +180,16 @@ metadata:
         {"interfaceName":"eth8","network":"vpc8"}
       ]
 spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: tcpxo
+            operator: In
+            values:
+            - daemon
+        topologyKey: "kubernetes.io/hostname"
   hostname: host2
   subdomain: nccl-host-2
   #  hostNetwork: true

--- a/gpudirect-tcpxo/nccl-test.yaml
+++ b/gpudirect-tcpxo/nccl-test.yaml
@@ -23,7 +23,18 @@ metadata:
   name: nccl-test-host-1
   labels:
     name: nccl-host-1
+    tcpxo: daemon 
 spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: tcpxo
+            operator: In
+            values:
+            - daemon
+        topologyKey: "kubernetes.io/hostname"
   hostname: host1
   subdomain: nccl-host-1
   hostNetwork: true
@@ -93,7 +104,18 @@ metadata:
   name: nccl-test-host-2
   labels:
     name: nccl-host-2
+    tcpxo: daemon
 spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: tcpxo
+            operator: In
+            values:
+            - daemon
+        topologyKey: "kubernetes.io/hostname"
   hostname: host2
   subdomain: nccl-host-2
   hostNetwork: true


### PR DESCRIPTION
Adding pod anti affinity rules and a label to examples to reduce the chance of scheduling multiple tcpxo-daemons on a single node.