### PR TITLE
Update partition-gpus image for H200

### DIFF
--- a/nvidia-driver-installer/cos/daemonset-nvidia-mig.yaml
+++ b/nvidia-driver-installer/cos/daemonset-nvidia-mig.yaml
@@ -101,7 +101,7 @@ spec:
           mountPath: /root
         - name: cos-tools
           mountPath: /build/cos-tools
-      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:7c13d18e82dc217aa4eaf5eaa0ebf4c41691ceb896c39f5d88917812ead4131a"
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:116be6b7335c1d34366223b9a3780fe80d862fcf06cd2c580426fdc1697af693"
         name: partition-gpus
         env:
         - name: LD_LIBRARY_PATH

--- a/nvidia-driver-installer/cos/daemonset-nvidia-mig.yaml
+++ b/nvidia-driver-installer/cos/daemonset-nvidia-mig.yaml
@@ -101,7 +101,7 @@ spec:
           mountPath: /root
         - name: cos-tools
           mountPath: /build/cos-tools
-      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:116be6b7335c1d34366223b9a3780fe80d862fcf06cd2c580426fdc1697af693"
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:7c13d18e82dc217aa4eaf5eaa0ebf4c41691ceb896c39f5d88917812ead4131a"
         name: partition-gpus
         env:
         - name: LD_LIBRARY_PATH

--- a/nvidia-driver-installer/cos/daemonset-nvidia-mig.yaml
+++ b/nvidia-driver-installer/cos/daemonset-nvidia-mig.yaml
@@ -101,7 +101,7 @@ spec:
           mountPath: /root
         - name: cos-tools
           mountPath: /build/cos-tools
-      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:e226275da6c45816959fe43cde907ee9a85c6a2aa8a429418a4cadef8ecdb86a"
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:116be6b7335c1d34366223b9a3780fe80d862fcf06cd2c580426fdc1697af693"
         name: partition-gpus
         env:
         - name: LD_LIBRARY_PATH

--- a/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
@@ -120,7 +120,7 @@ spec:
             /cos-gpu-installer install --version=latest || exit 1
             chmod 755 /root/home/kubernetes/bin/nvidia
           fi
-      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:e226275da6c45816959fe43cde907ee9a85c6a2aa8a429418a4cadef8ecdb86a"
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:116be6b7335c1d34366223b9a3780fe80d862fcf06cd2c580426fdc1697af693"
         name: partition-gpus
         env:
           - name: LD_LIBRARY_PATH

--- a/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
@@ -120,7 +120,7 @@ spec:
             /cos-gpu-installer install --version=latest || exit 1
             chmod 755 /root/home/kubernetes/bin/nvidia
           fi
-      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:116be6b7335c1d34366223b9a3780fe80d862fcf06cd2c580426fdc1697af693"
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:7c13d18e82dc217aa4eaf5eaa0ebf4c41691ceb896c39f5d88917812ead4131a"
         name: partition-gpus
         env:
           - name: LD_LIBRARY_PATH

--- a/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
@@ -120,7 +120,7 @@ spec:
             /cos-gpu-installer install --version=latest || exit 1
             chmod 755 /root/home/kubernetes/bin/nvidia
           fi
-      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:7c13d18e82dc217aa4eaf5eaa0ebf4c41691ceb896c39f5d88917812ead4131a"
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:116be6b7335c1d34366223b9a3780fe80d862fcf06cd2c580426fdc1697af693"
         name: partition-gpus
         env:
           - name: LD_LIBRARY_PATH

--- a/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded.yaml
@@ -119,7 +119,7 @@ spec:
             echo "No GPU driver module detected, installing now"
             /cos-gpu-installer install || exit 1
           fi
-      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:116be6b7335c1d34366223b9a3780fe80d862fcf06cd2c580426fdc1697af693"
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:7c13d18e82dc217aa4eaf5eaa0ebf4c41691ceb896c39f5d88917812ead4131a"
         name: partition-gpus
         env:
           - name: LD_LIBRARY_PATH

--- a/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded.yaml
@@ -119,7 +119,7 @@ spec:
             echo "No GPU driver module detected, installing now"
             /cos-gpu-installer install || exit 1
           fi
-      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:7c13d18e82dc217aa4eaf5eaa0ebf4c41691ceb896c39f5d88917812ead4131a"
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:116be6b7335c1d34366223b9a3780fe80d862fcf06cd2c580426fdc1697af693"
         name: partition-gpus
         env:
           - name: LD_LIBRARY_PATH

--- a/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded.yaml
@@ -119,7 +119,7 @@ spec:
             echo "No GPU driver module detected, installing now"
             /cos-gpu-installer install || exit 1
           fi
-      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:e226275da6c45816959fe43cde907ee9a85c6a2aa8a429418a4cadef8ecdb86a"
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:116be6b7335c1d34366223b9a3780fe80d862fcf06cd2c580426fdc1697af693"
         name: partition-gpus
         env:
           - name: LD_LIBRARY_PATH


### PR DESCRIPTION
A3 Ultra partition tests complained of an invalid partition size. I found the partition-gpus container image still used the old image lacking H200 partition profiles.