### PR TITLE
update topology aware scheduling logging for easier troubleshooting

### DIFF
--- a/gpudirect-tcpxo/topology-scheduler/schedule-daemon.py
+++ b/gpudirect-tcpxo/topology-scheduler/schedule-daemon.py
@@ -295,7 +295,7 @@ def can_schedule(node, pod):
   )
 
 
-def schedule_pod_on_node(v1, pod_name, pod_namespace, node_name, gate_name):
+def schedule_pod_on_node(v1, pod_name, pod_namespace, node, gate_name):
   """Schedules a pod on a given node."""
   try:
     pod = v1.read_namespaced_pod(pod_name, pod_namespace)
@@ -311,7 +311,7 @@ def schedule_pod_on_node(v1, pod_name, pod_namespace, node_name, gate_name):
                       'matchExpressions': [{
                           'key': 'kubernetes.io/hostname',
                           'operator': 'In',
-                          'values': [node_name],
+                          'values': [node['name']],
                       }]
                   }]
               }
@@ -321,7 +321,7 @@ def schedule_pod_on_node(v1, pod_name, pod_namespace, node_name, gate_name):
 
       v1.replace_namespaced_pod(pod_name, pod_namespace, pod)
 
-      print(f'Pod {pod_namespace}/{pod_name} scheduled on {node_name}')
+      print(f'Pod {pod_namespace}/{pod_name} scheduled on {node['name']} with topology: {node_topology_key(node)}')
   except ApiException as e:
     print(f'Exception when removing scheduling gate: {e}')
 
@@ -395,7 +395,7 @@ def schedule_pod_with_gate(v1, pods, gate):
       pod = sorted_pods[i]
       node = sorted_nodes[best_assignment[i]]
       schedule_pod_on_node(
-          v1, pod['name'], pod['namespace'], node['name'], gate
+          v1, pod['name'], pod['namespace'], node, gate
       )
 
 


### PR DESCRIPTION
Sample log:
```
2024-12-09 23:05:27,962 - root - INFO - Assignment found, scheduling my-sample-job with 8 pods.
2024-12-09 23:05:28,020 - root - INFO - Pod default/my-sample-job-0-8sq5g scheduled on gke-tii-on-gke-a3mega-a3mega-np-1-137c20ee-x79z with topology ('7d1ba2fc1fe47925a0ae8083c7e9f41b', '00e8fb6630bfcb9feff177c5643136b9', '456dc3a96a06ab5c5355ff3f26cdb909')
2024-12-09 23:05:28,057 - root - INFO - Pod default/my-sample-job-1-hp858 scheduled on gke-tii-on-gke-a3mega-a3mega-np-1-137c20ee-4wl0 with topology ('7d1ba2fc1fe47925a0ae8083c7e9f41b', '134e1eea7c4f0be251da22331a797ad9', '019dbdb5f06e8b23fd4b9038fcdb0ff4')
2024-12-09 23:05:28,093 - root - INFO - Pod default/my-sample-job-2-zxltf scheduled on gke-tii-on-gke-a3mega-a3mega-np-1-137c20ee-xp3p with topology ('7d1ba2fc1fe47925a0ae8083c7e9f41b', '33025660a515f2790a3a883ba965e014', '76c0495936c89aea0f23976a88ab6897')
2024-12-09 23:05:28,134 - root - INFO - Pod default/my-sample-job-3-mv2j5 scheduled on gke-tii-on-gke-a3mega-a3mega-np-1-137c20ee-4rv9 with topology ('7d1ba2fc1fe47925a0ae8083c7e9f41b', '41efc99a47c263f8261d7461cd83b658', 'd96d5606058e20f94c5925058e3efef2')
2024-12-09 23:05:28,171 - root - INFO - Pod default/my-sample-job-4-54wwl scheduled on gke-tii-on-gke-a3mega-a3mega-np-1-137c20ee-1gpl with topology ('7d1ba2fc1fe47925a0ae8083c7e9f41b', '52fa85f5ffd8ef1a76c303731e92ce6d', 'aa84296e1c6b666c0f2353af92cc8278')
2024-12-09 23:05:28,206 - root - INFO - Pod default/my-sample-job-5-lg6cg scheduled on gke-tii-on-gke-a3mega-a3mega-np-1-137c20ee-rsdt with topology ('7d1ba2fc1fe47925a0ae8083c7e9f41b', '52fa85f5ffd8ef1a76c303731e92ce6d', 'e2ea8d612f08a3bf15e32ca1b9fe1464')
2024-12-09 23:05:28,242 - root - INFO - Pod default/my-sample-job-6-pcxcm scheduled on gke-tii-on-gke-a3mega-a3mega-np-1-137c20ee-gxjk with topology ('7d1ba2fc1fe47925a0ae8083c7e9f41b', '7be2d1e23bff97428301c2f2d4a24c43', '339145deef94c8781516b03b628b81a2')
2024-12-09 23:05:28,283 - root - INFO - Pod default/my-sample-job-7-gpxnb scheduled on gke-tii-on-gke-a3mega-a3mega-np-1-137c20ee-c3b2 with topology ('7d1ba2fc1fe47925a0ae8083c7e9f41b', 'b3fee96ebe1261e9f5f998326efd4963', 'dd24710f564b53b53fceff51774a0c8c')
2024-12-09 23:05:28,310 - root - INFO - [Cool off] 60sec
