### PR TITLE
Add multi-arch image build for partition-gpu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,12 @@ push-multi-arch:
 	docker manifest push --purge ${REGISTRY}/${IMAGE}:${TAG}
 
 partition-gpu:
-	docker build --pull -t ${REGISTRY}/${PARTITION_GPU_IMAGE}:${TAG} -f partition_gpu/Dockerfile .
+	docker buildx build --pull --load -t ${REGISTRY}/${PARTITION_GPU_IMAGE}:${TAG} -f partition_gpu/Dockerfile .
+
+partition-gpu-multi-arch:
+	@for arch in $(ALL_ARCHITECTURES); do \
+	  docker buildx build --pull --load --platform linux/$${arch} -t ${REGISTRY}/${PARTITION_GPU_IMAGE}-$${arch}:${TAG} -f partition_gpu/Dockerfile . ; \
+	done
 
 fastsocket_installer:
 	docker build --pull -t ${REGISTRY}/${FASTSOCKET_INSTALLER_IMAGE}:${TAG} -f fast-socket-installer/image/Dockerfile .

--- a/partition_gpu/Dockerfile
+++ b/partition_gpu/Dockerfile
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23-bullseye as builder
+FROM --platform=$BUILDPLATFORM golang:1.23-bullseye as builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
 WORKDIR /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators
 COPY . .
-RUN go build -o gpu_partitioner partition_gpu/partition_gpu.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o gpu_partitioner partition_gpu/partition_gpu.go
 RUN chmod a+x /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators/gpu_partitioner
 
 FROM us.gcr.io/gke-release/gke-distroless/bash:gke_distroless_20250207.00_p0@sha256:dce99ff7978706ab3cabfeaae65d404d033d27a020e2c32a2f3a1daffd033343

--- a/partition_gpu/README.md
+++ b/partition_gpu/README.md
@@ -4,7 +4,7 @@ Simple command line tool to partition the GPUs as specified in a GPU configurati
 
 ## To build GPU partitoner image
 From root of the repository, run:
-  `docker build -f partition_gpu/Dockerfile .`
+  `docker buildx build --load -f partition_gpu/Dockerfile .`
 
 ## To deploy GPU partitioner on all GPU nodes in GKE cluster
   `kubectl apply -f partition_gpu.yaml`


### PR DESCRIPTION
* Create new make target for  multi-arch build
* Update existing single-arch make target
* Can reutilize `push-all` and `push-multi-arch` to push mutli-arch manifest

Manually tested image creation and verified no regressions