### PR TITLE
Exposing NUMA node information in the device topology hints

### DIFF
--- a/pkg/gpu/nvidia/beta_plugin.go
+++ b/pkg/gpu/nvidia/beta_plugin.go
@@ -45,7 +45,7 @@ func (s *pluginServiceV1Beta1) ListAndWatch(emtpy *pluginapi.Empty, stream plugi
 		select {
 		case d := <-s.ngm.Health:
 			glog.Infof("device-plugin: %s device marked as %s", d.ID, d.Health)
-			s.ngm.SetDeviceHealth(d.ID, d.Health)
+			s.ngm.SetDeviceHealth(d.ID, d.Health, d.Topology)
 			if err := s.sendDevices(stream); err != nil {
 				return err
 			}
@@ -133,7 +133,7 @@ func RegisterWithV1Beta1Kubelet(kubeletEndpoint, pluginEndpoint, resourceName st
 func (s *pluginServiceV1Beta1) sendDevices(stream pluginapi.DevicePlugin_ListAndWatchServer) error {
 	resp := new(pluginapi.ListAndWatchResponse)
 	for _, dev := range s.ngm.ListDevices() {
-		resp.Devices = append(resp.Devices, &pluginapi.Device{ID: dev.ID, Health: dev.Health})
+		resp.Devices = append(resp.Devices, &pluginapi.Device{ID: dev.ID, Health: dev.Health, Topology: dev.Topology})
 	}
 	glog.Infof("ListAndWatch: send devices %v\n", resp)
 	if err := stream.Send(resp); err != nil {

--- a/pkg/gpu/nvidia/beta_plugin_test.go
+++ b/pkg/gpu/nvidia/beta_plugin_test.go
@@ -271,6 +271,12 @@ func testNvidiaGPUManagerBetaAPI(gpuConfig GPUConfig, wantDevices map[string]*pl
 		return fmt.Errorf("failed to initilize a GPU manager")
 	}
 
+	// overriding nvmlDeviceInfo to mockDeviceInfo interface
+	nvmlDeviceInfo = &mockDeviceInfo{}
+	mockInfo, _ := nvmlDeviceInfo.(*mockDeviceInfo)
+
+	mockInfo.testDevDir = testDevDir
+
 	// Start GPU manager.
 	if err := testGpuManager.Start(); err != nil {
 		return fmt.Errorf("unable to start gpu manager: %w", err)
@@ -282,6 +288,7 @@ func testNvidiaGPUManagerBetaAPI(gpuConfig GPUConfig, wantDevices map[string]*pl
 	if discoverErr != nil {
 		return discoverErr
 	}
+
 	gpus := reflect.ValueOf(testGpuManager).Elem().FieldByName("devices").Len()
 	if gpus == 0 {
 		return fmt.Errorf("unable to discover GPU devices")
@@ -331,6 +338,7 @@ func testNvidiaGPUManagerBetaAPI(gpuConfig GPUConfig, wantDevices map[string]*pl
 	for _, d := range devs.Devices {
 		devices[d.ID] = d
 	}
+
 	if diff := cmp.Diff(wantDevices, devices); diff != "" {
 		return fmt.Errorf("unexpected devices (-want, +got) = %s", diff)
 	}
@@ -446,6 +454,12 @@ func testNvidiaGPUManagerBetaAPIWithMig(gpuConfig GPUConfig, wantDevices map[str
 	if testGpuManager == nil {
 		return fmt.Errorf("failed to initilize a GPU manager")
 	}
+
+	// overriding nvmlDeviceInfo to mockDeviceInfo interface
+	nvmlDeviceInfo = &mockDeviceInfo{}
+	mockInfo, _ := nvmlDeviceInfo.(*mockDeviceInfo)
+
+	mockInfo.testDevDir = testDevDir
 
 	// Start GPU manager.
 	if err := testGpuManager.Start(); err != nil {

--- a/pkg/gpu/nvidia/manager.go
+++ b/pkg/gpu/nvidia/manager.go
@@ -63,7 +63,8 @@ const (
 )
 
 var (
-	resourceName = "nvidia.com/gpu"
+	resourceName   = "nvidia.com/gpu"
+	pciDevicesRoot = "/sys/bus/pci/devices"
 )
 
 // GPUConfig stores the settings used to configure the GPUs on a node.
@@ -190,7 +191,7 @@ func (ngm *nvidiaGPUManager) ListDevices() map[string]pluginapi.Device {
 			for i := 0; i < ngm.gpuConfig.GPUSharingConfig.MaxSharedClientsPerGPU; i++ {
 				virtualDeviceID := fmt.Sprintf("%s/vgpu%d", device.ID, i)
 				// When sharing GPUs, the virtual GPU device will inherit the health status from its underlying physical GPU device.
-				virtualGPUDevices[virtualDeviceID] = pluginapi.Device{ID: virtualDeviceID, Health: device.Health}
+				virtualGPUDevices[virtualDeviceID] = pluginapi.Device{ID: virtualDeviceID, Health: device.Health, Topology: device.Topology}
 			}
 		}
 		return virtualGPUDevices
@@ -229,21 +230,184 @@ func (ngm *nvidiaGPUManager) DeviceSpec(deviceID string) ([]pluginapi.DeviceSpec
 	return ngm.migDeviceManager.DeviceSpec(deviceID)
 }
 
+type nvmlOperations interface {
+	deviceCount() (int, nvml.Return)
+	deviceHandleByIndex(int) (nvml.Device, nvml.Return)
+	migDeviceHandleByIndex(nvml.Device, int) (nvml.Device, nvml.Return)
+	migMode(nvml.Device) (int, int, nvml.Return)
+	minorNumber(nvml.Device) (int, nvml.Return)
+	pciInfo(d nvml.Device) (nvml.PciInfo, nvml.Return)
+}
+
+// Declare an interface variable for NVML operations.
+// This allows the interface to be overriden with mock
+// implementations in the tests.
+var nvmlDeviceInfo nvmlOperations
+
+// deviceInfo is a struct that implements the nvmlOperations interface.
+type deviceInfo struct{}
+
+func (gpuDeviceInfo *deviceInfo) deviceCount() (int, nvml.Return) {
+	return nvml.DeviceGetCount()
+}
+
+func (gpuDeviceInfo *deviceInfo) deviceHandleByIndex(i int) (nvml.Device, nvml.Return) {
+	return nvml.DeviceGetHandleByIndex(i)
+}
+
+func (gpuDeviceInfo *deviceInfo) migDeviceHandleByIndex(d nvml.Device, i int) (nvml.Device, nvml.Return) {
+	return d.GetMigDeviceHandleByIndex(i)
+}
+
+// migMode call's NVML device's GetMigMode() which returns:
+// Current mode: The currently active MIG mode
+// Pending mode: The MIG mode that will be applied after the next
+// GPU reset or system reboot
+// Return: NVML return code indicating success or specific error
+func (gpuDeviceInfo *deviceInfo) migMode(d nvml.Device) (int, int, nvml.Return) {
+	return d.GetMigMode()
+}
+
+func (gpuDeviceInfo *deviceInfo) minorNumber(d nvml.Device) (int, nvml.Return) {
+	return d.GetMinorNumber()
+}
+
+func (gpuDeviceInfo *deviceInfo) pciInfo(d nvml.Device) (nvml.PciInfo, nvml.Return) {
+	return d.GetPciInfo()
+}
+
+// topology determines the NUMA topology information for a GPU device.
+// For MIG-enabled GPUs, it retrieves the NUMA node ID from the parent GPU device.
+// For non-MIG GPUs, it gets the NUMA node ID directly from the GPU device.
+// Returns a TopologyInfo containing the NUMA node ID if NUMA is enabled, nil
+// otherwise.
+// Example for a GPU device associated with NUMA node 1
+//
+//	topologyInfo := &pluginapi.TopologyInfo{
+//	    Nodes: []*pluginapi.NUMANode{
+//	        {
+//	            ID: 1,
+//	        },
+//	    },
+//	}
+func topology(d nvml.Device, i int) (*pluginapi.TopologyInfo, error) {
+	if nvmlDeviceInfo == nil {
+		nvmlDeviceInfo = &deviceInfo{}
+	}
+
+	// We only care about currentMode which indicates the current MIG mode state.
+	// The pendingMode is ignored as we're only interested in the current
+	// operational state, not future configurations.
+	currentMode, _, ret := nvmlDeviceInfo.migMode(d)
+	if ret != nvml.ERROR_NOT_SUPPORTED {
+		if ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("failed to get mig mode: %v", nvml.ErrorString(ret))
+		}
+	}
+
+	// For GPU topology information: When MIG (Multi-Instance GPU) is enabled, retrieve
+	// the NUMA node ID from the parent GPU device. Otherwise, get the NUMA node ID
+	// directly from the GPU device itself.
+	numaDevice := d
+	// A currentMode value of 1 means MIG is currently enabled on the device,
+	// while 0 means MIG is disabled.
+	if currentMode == 1 {
+		parent, ret := nvmlDeviceInfo.migDeviceHandleByIndex(d, i)
+		if ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("failed to get mig device handle: %v", nvml.ErrorString(ret))
+		}
+		numaDevice = parent
+
+	}
+	numaEnabled, node, err := numaNode(numaDevice)
+	if err != nil {
+		return nil, err
+	}
+
+	if !numaEnabled {
+		return nil, nil
+	}
+
+	return &pluginapi.TopologyInfo{
+		Nodes: []*pluginapi.NUMANode{
+			{
+				ID: int64(node),
+			},
+		},
+	}, nil
+}
+
+// numaNode retrieves the NUMA node information for a given GPU device.
+// It first gets the PCI bus ID from the device, formats it appropriately,
+// then reads the NUMA node value from the sysfs filesystem.
+func numaNode(d nvml.Device) (numaEnabled bool, numaNode int, err error) {
+	if nvmlDeviceInfo == nil {
+		nvmlDeviceInfo = &deviceInfo{}
+	}
+	pciInfo, ret := nvmlDeviceInfo.pciInfo(d)
+	if ret != nvml.SUCCESS {
+		return false, 0, fmt.Errorf("error getting PCI Bus Info of device with index: %v", ret)
+	}
+
+	var bytesT []byte
+	for _, b := range pciInfo.BusId {
+		if byte(b) == '\x00' {
+			break
+		}
+		bytesT = append(bytesT, byte(b))
+	}
+
+	// Discard leading zeros.
+	busID := strings.ToLower(strings.TrimPrefix(string(bytesT), "0000"))
+
+	numaNodeFile := fmt.Sprintf("%s/%s/numa_node", pciDevicesRoot, busID)
+	glog.Infof("Reading NUMA node information from %q", numaNodeFile)
+	b, err := os.ReadFile(numaNodeFile)
+	if err != nil {
+		return false, 0, fmt.Errorf("failed to read NUMA information from %q file: %v", numaNodeFile, err)
+	}
+
+	numaNode, err = strconv.Atoi(string(bytes.TrimSpace(b)))
+	if err != nil {
+		return false, 0, fmt.Errorf("eror parsing value for NUMA node: %v", err)
+	}
+
+	if numaNode < 0 {
+		return false, 0, nil
+	}
+
+	return true, numaNode, nil
+}
+
 // Discovers all NVIDIA GPU devices available on the local node by walking nvidiaGPUManager's devDirectory.
 func (ngm *nvidiaGPUManager) discoverGPUs() error {
-	reg := regexp.MustCompile(nvidiaDeviceRE)
-	files, err := ioutil.ReadDir(ngm.devDirectory)
-	if err != nil {
-		return err
+	if nvmlDeviceInfo == nil {
+		nvmlDeviceInfo = &deviceInfo{}
 	}
-	for _, f := range files {
-		if f.IsDir() {
-			continue
+
+	devicesCount, ret := nvmlDeviceInfo.deviceCount()
+	if ret != nvml.SUCCESS {
+		return fmt.Errorf("failed to get devices count: %v", nvml.ErrorString(ret))
+	}
+
+	for i := 0; i < devicesCount; i++ {
+		device, ret := nvmlDeviceInfo.deviceHandleByIndex((i))
+		if ret != nvml.SUCCESS {
+			return fmt.Errorf("failed to get the device handle for index %d: %v", i, nvml.ErrorString(ret))
 		}
-		if reg.MatchString(f.Name()) {
-			glog.V(3).Infof("Found Nvidia GPU %q\n", f.Name())
-			ngm.SetDeviceHealth(f.Name(), pluginapi.Healthy)
+
+		minor, ret := nvmlDeviceInfo.minorNumber(device)
+		if ret != nvml.SUCCESS {
+			return fmt.Errorf("failed to get the minor number for device with index %d: %v", i, nvml.ErrorString(ret))
 		}
+
+		path := fmt.Sprintf("nvidia%d", minor)
+		glog.V(3).Infof("Found Nvidia GPU %q\n", path)
+		topologyInfo, err := topology(device, i)
+		if err != nil {
+			glog.Errorln(err)
+		}
+		ngm.SetDeviceHealth(path, pluginapi.Healthy, topologyInfo)
 	}
 	return nil
 }
@@ -327,13 +491,13 @@ func (ngm *nvidiaGPUManager) Envs(numDevicesRequested int) map[string]string {
 }
 
 // SetDeviceHealth sets the health status for a GPU device or partition if MIG is enabled
-func (ngm *nvidiaGPUManager) SetDeviceHealth(name string, health string) {
+func (ngm *nvidiaGPUManager) SetDeviceHealth(name string, health string, topology *pluginapi.TopologyInfo) {
 	ngm.devicesMutex.Lock()
 	defer ngm.devicesMutex.Unlock()
 
 	reg := regexp.MustCompile(nvidiaDeviceRE)
 	if reg.MatchString(name) {
-		ngm.devices[name] = pluginapi.Device{ID: name, Health: health}
+		ngm.devices[name] = pluginapi.Device{ID: name, Health: health, Topology: topology}
 	} else {
 		ngm.migDeviceManager.SetDeviceHealth(name, health)
 	}

--- a/pkg/gpu/nvidia/nvml_mock.go
+++ b/pkg/gpu/nvidia/nvml_mock.go
@@ -1,0 +1,68 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file mocks NVML library methods for unit tests.
+
+package nvidia
+
+import (
+	"io/ioutil"
+	"regexp"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+type mockDeviceInfo struct {
+	currentDevice int
+	testDevDir    string
+	busID         [32]int8
+}
+
+func (gpuDeviceInfo *mockDeviceInfo) deviceCount() (int, nvml.Return) {
+	reg := regexp.MustCompile(nvidiaDeviceRE)
+
+	files, _ := ioutil.ReadDir(gpuDeviceInfo.testDevDir)
+
+	numDevices := 0
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		if reg.MatchString(f.Name()) {
+			numDevices += 1
+		}
+	}
+	return numDevices, nvml.SUCCESS
+}
+
+func (gpuDeviceInfo *mockDeviceInfo) deviceHandleByIndex(i int) (nvml.Device, nvml.Return) {
+	gpuDeviceInfo.currentDevice = i
+	return nvml.Device{}, nvml.SUCCESS
+}
+
+func (gpuDeviceInfo *mockDeviceInfo) migDeviceHandleByIndex(d nvml.Device, i int) (nvml.Device, nvml.Return) {
+	return nvml.Device{}, nvml.SUCCESS
+}
+
+func (gpuDeviceInfo *mockDeviceInfo) migMode(d nvml.Device) (int, int, nvml.Return) {
+	return 0, 0, nvml.SUCCESS
+}
+
+func (gpuDeviceInfo *mockDeviceInfo) minorNumber(d nvml.Device) (int, nvml.Return) {
+	return gpuDeviceInfo.currentDevice, nvml.SUCCESS
+}
+
+func (gpuDeviceInfo *mockDeviceInfo) pciInfo(d nvml.Device) (nvml.PciInfo, nvml.Return) {
+	return nvml.PciInfo{BusId: gpuDeviceInfo.busID}, nvml.SUCCESS
+}


### PR DESCRIPTION
This change exposes the topology hints for GPU in the device plugin for kubelet.

Testing workflow:

# Pushed the image to a registry
go mod tidy
make build
make REGISTRY=$REGISTRY IMAGE=$IMAGE TAG=$TAG container
docker push $REGISTRY/$IMAGE:$TAG

# Edited to replace the device plugin image with image with my changes
kubectl edit ds/$DEVICE_PLUGIN_DS -n kube-system

# install the GPU driver
kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml



