### PR TITLE
Update driver installer to support non-preloading image temporally 

### DIFF
--- a/nvidia-driver-installer/cos/daemonset-preloaded-latest-a4x.yaml
+++ b/nvidia-driver-installer/cos/daemonset-preloaded-latest-a4x.yaml
@@ -78,7 +78,7 @@ spec:
         hostPath:
           path: /etc/nvidia
       initContainers:
-      - image: "cos-nvidia-installer:fixed"
+      - image: "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
         imagePullPolicy: Never
         name: nvidia-driver-installer
         resources:


### PR DESCRIPTION
Available extensions for COS version 117-18613.164.28:

[gpu]
gpu installer: us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7
