### PR TITLE
remove gvnic-1 from rdma pod manifests

### DIFF
--- a/gpudirect-rdma/nccl-test-a4.yaml
+++ b/gpudirect-rdma/nccl-test-a4.yaml
@@ -27,7 +27,6 @@ metadata:
     networking.gke.io/interfaces: |
       [
         {"interfaceName":"eth0","network":"default"},
-        {"interfaceName":"eth1","network":"gvnic-1"},
         {"interfaceName":"eth2","network":"rdma-0"},
         {"interfaceName":"eth3","network":"rdma-1"},
         {"interfaceName":"eth4","network":"rdma-2"},
@@ -88,7 +87,6 @@ metadata:
     networking.gke.io/interfaces: |
       [
         {"interfaceName":"eth0","network":"default"},
-        {"interfaceName":"eth1","network":"gvnic-1"},
         {"interfaceName":"eth2","network":"rdma-0"},
         {"interfaceName":"eth3","network":"rdma-1"},
         {"interfaceName":"eth4","network":"rdma-2"},

--- a/gpudirect-rdma/nccl-test.yaml
+++ b/gpudirect-rdma/nccl-test.yaml
@@ -41,7 +41,6 @@ metadata:
     networking.gke.io/interfaces: |
       [
         {"interfaceName":"eth0","network":"default"},
-        {"interfaceName":"eth1","network":"gvnic-1"},
         {"interfaceName":"eth2","network":"rdma-0"},
         {"interfaceName":"eth3","network":"rdma-1"},
         {"interfaceName":"eth4","network":"rdma-2"},
@@ -100,7 +99,6 @@ metadata:
     networking.gke.io/interfaces: |
       [
         {"interfaceName":"eth0","network":"default"},
-        {"interfaceName":"eth1","network":"gvnic-1"},
         {"interfaceName":"eth2","network":"rdma-0"},
         {"interfaceName":"eth3","network":"rdma-1"},
         {"interfaceName":"eth4","network":"rdma-2"},


### PR DESCRIPTION
It's not needed by NCCL tests