### PR TITLE
Update nccl-rdma-installer manifest for A4x

### DIFF
--- a/gpudirect-rdma/nccl-rdma-installer-a4x.yaml
+++ b/gpudirect-rdma/nccl-rdma-installer-a4x.yaml
@@ -74,54 +74,6 @@ spec:
               sysctl -w net.ipv4.conf.gpu1rdma0.log_martians=0
               sysctl -w net.ipv4.conf.gpu2rdma0.log_martians=0
               sysctl -w net.ipv4.conf.gpu3rdma0.log_martians=0
-        - name: nvidia-container-toolkit-installer
-          image: ubuntu:22.04
-          securityContext:
-            privileged: true
-          env:
-            - name: LD_LIBRARY_PATH
-              value: /host/home/kubernetes/bin/nvidia/lib64
-          volumeMounts:
-            - name: nvidia-dir
-              mountPath: /host/home/kubernetes/bin/nvidia
-          command:
-            - bash
-            - -c
-            - |
-              set -ex
-              if [ -f /host/home/kubernetes/bin/nvidia/nvidia-ctk ]; then
-                echo "NVIDIA Container Toolkit already exists, skipping installation."
-              else
-                echo "Installing NVIDIA Container Toolkit..."
-
-                while true; do
-                  DRIVER_VERSION=$("/host/home/kubernetes/bin/nvidia/bin/nvidia-smi" --query-gpu=driver_version --format=csv,noheader --id=0 2>&1)
-
-                  if [ $? -eq 0 ] && [ -n "$DRIVER_VERSION" ]; then
-                    echo "NVIDIA driver detected: version $DRIVER_VERSION"
-                    break
-                  else
-                    echo "NVIDIA driver not available yet. Retrying in 5 seconds..."
-                    sleep 5
-                  fi
-                done
-
-                apt update
-                apt install -y curl gnupg2 ca-certificates
-
-                curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
-                  gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
-
-                curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
-                  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-                  tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-
-                apt update
-                apt install -y nvidia-container-toolkit
-
-                cp /usr/bin/nvidia-* /host/home/kubernetes/bin/nvidia
-                echo "NVIDIA Container Toolkit installation complete."
-              fi
         - image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-arm64:v1.0.4
           name: nccl-rdma-installer
           resources:


### PR DESCRIPTION
As part of the update to the DRA gpu driver v25.3.0-rc.3 https://github.com/NVIDIA/k8s-dra-driver-gpu/discussions/399, the  dependency on the pre-provisioned NVIDIA Container Toolkit is removed. This PR removes the init-container that installs the container toolkit. 