### PR TITLE
Using hybrid method to combine allocatable wait and flock wait

### DIFF
--- a/cmd/nvidia_gpu/nvidia_gpu.go
+++ b/cmd/nvidia_gpu/nvidia_gpu.go
@@ -15,10 +15,12 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"time"
 
 	gpumanager "github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia"
@@ -27,6 +29,8 @@ import (
 	util "github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/util"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/golang/glog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
@@ -35,6 +39,9 @@ const (
 	kubeletEndpoint      = "kubelet.sock"
 	pluginEndpointPrefix = "nvidiaGPU"
 	devDirectory         = "/dev"
+	nodeNameEnv          = "NODE_NAME"
+	lockFilePath         = "/device-plugin/tpu-device-plugin.lock"
+
 	// Proc directory is used to lookup the access files for each GPU partition.
 	procDirectory = "/proc"
 )
@@ -47,6 +54,7 @@ var (
 	pluginMountPath                = flag.String("plugin-directory", "/device-plugin", "The directory path to create plugin socket")
 	enableContainerGPUMetrics      = flag.Bool("enable-container-gpu-metrics", false, "If true, the device plugin will expose GPU metrics for containers with allocated GPU")
 	enableHealthMonitoring         = flag.Bool("enable-health-monitoring", false, "If true, the device plugin will detect critical Xid errors and mark the GPUs unallocatable")
+	enableFlockWait                = flag.Bool("enable-flock-wait", false, "If true, the device plugin will wait until the old device plugin release the lock")
 	gpuMetricsPort                 = flag.Int("gpu-metrics-port", 2112, "Port on which GPU metrics for containers are exposed")
 	gpuMetricsCollectionIntervalMs = flag.Int("gpu-metrics-collection-interval", 30000, "Collection interval (in milli seconds) for container GPU metrics")
 	gpuConfigFile                  = flag.String("gpu-config", "/etc/nvidia/gpu_config.json", "File with GPU configurations for device plugin")
@@ -73,6 +81,8 @@ func parseGPUConfig(gpuConfigFile string) (gpumanager.GPUConfig, error) {
 
 func main() {
 	flag.Parse()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // Ensure the context is canceled when main exits
 	glog.Infoln("device-plugin started")
 	mountPaths := []pluginapi.Mount{
 		{HostPath: *hostPathPrefix, ContainerPath: *containerPathPrefix, ReadOnly: true},
@@ -151,6 +161,29 @@ func main() {
 			return
 		}
 		defer hc.Stop()
+
+	}
+
+	if *enableFlockWait {
+		kubeClient, err := util.BuildKubeClient()
+		if err != nil {
+			glog.Infof("Failed to build kube client: %v", err)
+			return
+		}
+		nodeName, err := util.GetEnvName(nodeNameEnv)
+		if err != nil {
+			glog.Infof("Failed to get node name from environment variable %s: %v", nodeNameEnv, err)
+			return
+		}
+		watchfunc := func(options metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().Nodes().Watch(context.TODO(), metav1.ListOptions{
+				FieldSelector: "metadata.name=" + nodeName,
+			})
+		}
+		if err := util.SafelyUsingFlockWait(ctx, lockFilePath, watchfunc, util.CheckLockFileExists, util.UseRetryWatch); err != nil {
+			glog.Errorf("Failed to safely use flock wait, exiting... %v", err)
+			os.Exit(1)
+		}
 	}
 
 	ngm.Serve(*pluginMountPath, kubeletEndpoint, fmt.Sprintf("%s-%d.sock", pluginEndpointPrefix, time.Now().Unix()))

--- a/pkg/gpu/nvidia/util/util.go
+++ b/pkg/gpu/nvidia/util/util.go
@@ -15,16 +15,26 @@
 package util
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"regexp"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/golang/glog"
+	"golang.org/x/sys/unix"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/watch"
 	client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	retryWatch "k8s.io/client-go/tools/watch"
 )
+
+const ()
 
 func DeviceNameFromPath(path string) (string, error) {
 	gpuPathRegex := regexp.MustCompile("/dev/(nvidia[0-9]+)$")
@@ -60,11 +70,105 @@ func BuildKubeClient() (client.Interface, error) {
 	}
 	config.ContentType = runtime.ContentTypeProtobuf
 
-	kubeClient, err := kubernetes.NewForConfig(config)
+	kubeClient, err := client.NewForConfig(config)
 	if err != nil {
 		glog.Errorf("failed to get kube client. Error: %v", err)
 		return nil, err
 	}
 
 	return kubeClient, nil
+}
+
+func GetEnvName(envName string) (string, error) {
+	env := os.Getenv(envName)
+	if len(env) == 0 {
+		return "", fmt.Errorf("empty %s environment variable", envName)
+	}
+	return env, nil
+}
+
+func CheckLockFileExists(lockFilePath string) (bool, error) {
+	if _, err := os.Stat(lockFilePath); err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	} else {
+		return false, err
+	}
+}
+
+// Function containing the blocking logic that processes node events
+func WaitForDeviceUnregistered(event watch.Event) (bool, error) {
+	if event.Type == watch.Modified || event.Type == watch.Added {
+		node, ok := event.Object.(*v1.Node)
+		if !ok {
+			glog.Warningf("unexpected object type: %T", event.Object)
+			return false, nil
+		}
+
+		tpuQuantity, exists := node.Status.Allocatable["nvidia.com/gpu"]
+		if !exists || tpuQuantity.Value() == 0 {
+			glog.Infoln("nvidia.com/gpu is 0. Proceeding to critical section.")
+			return true, nil
+		}
+		glog.Infoln("Waiting for nvidia.com/gpu to be 0...", tpuQuantity.Value())
+		return false, nil
+	}
+	if event.Type == watch.Deleted {
+		return true, fmt.Errorf("node deleted, exit here")
+	}
+	if event.Type == watch.Error {
+		return true, fmt.Errorf("node error received, exit here: %v", apierrors.FromObject(event.Object))
+	}
+	return false, nil
+}
+
+// Copyied from k8s.io/kubernetes/pkg/util/flock
+// Acquire acquires a lock on a file for the duration of the process. This method
+// is reentrant.
+func Acquire(path string) error {
+	fd, err := unix.Open(path, unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC, 0600)
+	if err != nil {
+		return err
+	}
+
+	// We don't need to close the fd since we should hold
+	// it until the process exits.
+
+	return unix.Flock(fd, unix.LOCK_EX)
+}
+
+func UseRetryWatch(ctx context.Context, watchFunc func(metav1.ListOptions) (watch.Interface, error), conditions func(watch.Event) (bool, error)) error {
+	_, err := retryWatch.Until(ctx, "1", &cache.ListWatch{WatchFunc: watchFunc}, conditions)
+	if err != nil {
+		return fmt.Errorf("failed to wait for device unregistered: %v", err)
+	}
+	return nil
+}
+
+func SafelyUsingFlockWait(
+	ctx context.Context,
+	lockFilePath string,
+	watchFunc func(metav1.ListOptions) (watch.Interface, error),
+	checkLockFileExists func(lockFilePath string) (bool, error),
+	useRetryWatch func(
+		ctx context.Context,
+		watchFunc func(metav1.ListOptions) (watch.Interface, error),
+		conditions func(watch.Event) (bool, error),
+	) error,
+) error {
+	if val, err := checkLockFileExists(lockFilePath); err != nil {
+		return fmt.Errorf("error checking lock file %q: %q", lockFilePath, err)
+	} else if !val {
+		glog.Infof("Lock file %q does not exist\n", lockFilePath)
+		if err := useRetryWatch(ctx, watchFunc, WaitForDeviceUnregistered); err != nil {
+			return fmt.Errorf("failed to use retry watch: %v", err)
+		}
+	}
+
+	glog.Infof("Attempting to acquire lock on %q...\n", lockFilePath)
+	if err := Acquire(lockFilePath); err != nil {
+		return fmt.Errorf("error acquiring lock: %v", err)
+	}
+	return nil
 }

--- a/pkg/gpu/nvidia/util/util_test.go
+++ b/pkg/gpu/nvidia/util/util_test.go
@@ -15,9 +15,20 @@
 package util
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 func TestDeviceNameFromPath(t *testing.T) {
@@ -29,4 +40,234 @@ func TestDeviceNameFromPath(t *testing.T) {
 	name, err = DeviceNameFromPath("/dev/somethingelse0")
 	as.Error(err)
 	as.Contains(err.Error(), "is not a valid GPU device path")
+}
+
+func TestWaitForDeviceUnregistered(t *testing.T) {
+	errorEvent := watch.Event{
+		Type: watch.Error,
+		Object: &metav1.Status{
+			Reason: "test error",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		event    watch.Event
+		wantBool bool
+		wantErr  error
+	}{
+		{
+			name: "Modified event, GPU is 0",
+			event: watch.Event{
+				Type: watch.Modified,
+				Object: &v1.Node{
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("0"),
+						},
+					},
+				},
+			},
+			wantBool: true,
+			wantErr:  nil,
+		},
+		{
+			name: "Added event, GPU exists and is greater than 0",
+			event: watch.Event{
+				Type: watch.Added,
+				Object: &v1.Node{
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("1"),
+						},
+					},
+				},
+			},
+			wantBool: false,
+			wantErr:  nil,
+		},
+		{
+			name: "Modified event, GPU does not exist",
+			event: watch.Event{
+				Type: watch.Modified,
+				Object: &v1.Node{
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{},
+					},
+				},
+			},
+			wantBool: true,
+			wantErr:  nil,
+		},
+		{
+			name: "Deleted event",
+			event: watch.Event{
+				Type:   watch.Deleted,
+				Object: &v1.Node{}, // Object doesn't matter for Deleted event
+			},
+			wantBool: true,
+			wantErr:  fmt.Errorf("node deleted, exit here"),
+		},
+		{
+			name:     "Error event",
+			event:    errorEvent,
+			wantBool: true,
+			wantErr:  fmt.Errorf("node error received, exit here: %v", apierrors.FromObject(errorEvent.Object)),
+		},
+		{
+			name: "Unexpected object type",
+			event: watch.Event{
+				Type:   watch.Modified,
+				Object: &v1.Pod{}, // Not a v1.Node
+			},
+			wantBool: false,
+			wantErr:  nil,
+		},
+		{
+			name: "Unknown event type",
+			event: watch.Event{
+				Type:   watch.EventType("UNKNOWN"),
+				Object: &v1.Node{},
+			},
+			wantBool: false,
+			wantErr:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			boolResult, err := WaitForDeviceUnregistered(test.event)
+
+			if boolResult != test.wantBool {
+				t.Errorf("WaitForDevicePluginShutdownCondition() gotBool = %v, want %v", boolResult, test.wantBool)
+			}
+
+			if (err != nil && test.wantErr == nil) || (err == nil && test.wantErr != nil) {
+				t.Errorf("WaitForDevicePluginShutdownCondition() gotErr = %v, want %v", err, test.wantErr)
+			} else if err != nil && test.wantErr != nil && err.Error() != test.wantErr.Error() {
+				t.Errorf("WaitForDevicePluginShutdownCondition() gotErr = %v, want %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestSafelyUsingFlockWait(t *testing.T) {
+	const eventDuration = 50 * time.Millisecond
+	const lockFileDuration = 100 * time.Millisecond
+
+	tests := []struct {
+		name            string
+		locked          bool
+		created         bool
+		watchFuncCalled bool
+		minTimeDuration time.Duration
+		maxTimeDuration time.Duration
+	}{
+		{
+			name:            "LockFileExistsLocked",
+			locked:          true,
+			created:         true,
+			watchFuncCalled: false,
+			minTimeDuration: 100 * time.Millisecond,
+			maxTimeDuration: 105 * time.Millisecond,
+		},
+		{
+			name:            "LockFileExistsNotLocked",
+			locked:          false,
+			created:         true,
+			watchFuncCalled: false,
+			minTimeDuration: 0,
+			maxTimeDuration: 1 * time.Millisecond,
+		},
+		{
+			name:            "LockFileNotExists",
+			locked:          false,
+			created:         false,
+			watchFuncCalled: true,
+			minTimeDuration: 50 * time.Millisecond,
+			maxTimeDuration: 52 * time.Millisecond,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const lockFileName string = "file.lock"
+
+			var fd int
+			var duration time.Duration
+			var funcErr error
+
+			ctx := context.Background()
+
+			tempDir, err := os.MkdirTemp("", "lockfile_test_")
+			if err != nil {
+				t.Fatalf("Failed to create temporary directory: %v", err)
+			}
+			defer os.RemoveAll(tempDir)
+			lockFilePath := filepath.Join(tempDir, lockFileName)
+
+			// Create lock file
+			if tt.created {
+				file, err := os.Create(lockFilePath)
+				if err != nil {
+					t.Fatalf("Failed to create dummy lock file: %v", err)
+				}
+				file.Close()
+			}
+
+			// Lock the file
+			if tt.locked {
+				fd, err = unix.Open(lockFilePath, unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC, 0600)
+				if err != nil {
+					t.Errorf("Failed to open lock file: %v", err)
+				}
+				err = unix.Flock(fd, unix.LOCK_EX)
+				if err != nil {
+					t.Errorf("Failed to lock file: %v", err)
+				}
+			}
+			mockCheckLockFileExists := func(string) (bool, error) {
+				if tt.locked {
+					time.Sleep(lockFileDuration)
+
+					err = unix.Flock(fd, unix.LOCK_UN)
+					if err != nil {
+						t.Errorf("Failed to lock file: %v", err)
+					}
+					return true, nil
+				}
+				return false, nil
+			}
+			mockWathchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
+				return nil, nil
+			}
+
+			mockUseRetryWatch := func(context.Context, func(options metav1.ListOptions) (watch.Interface, error), func(watch.Event) (bool, error)) error {
+				if tt.watchFuncCalled {
+					time.Sleep(eventDuration)
+				}
+				return nil
+			}
+
+			startTime := time.Now()
+
+			funcErr = SafelyUsingFlockWait(ctx, lockFilePath, mockWathchFunc, mockCheckLockFileExists, mockUseRetryWatch)
+			if funcErr != nil {
+				t.Errorf("SafelyUsingFlockWait() returned unexpected error: %v", funcErr)
+			}
+			duration = time.Since(startTime)
+
+			if duration < tt.minTimeDuration || duration > tt.maxTimeDuration {
+				t.Errorf("Expected SafelyUsingFlockWait() to finish between %v and %v, but it took %v", tt.minTimeDuration, tt.maxTimeDuration, duration)
+			}
+
+			fd, err = unix.Open(lockFilePath, unix.O_RDWR|unix.O_CLOEXEC, 0600)
+			if err != nil {
+				t.Errorf("Failed to open lock file: %v", err)
+			}
+			err = unix.Flock(fd, unix.LOCK_NB|unix.LOCK_EX)
+			if err != unix.EWOULDBLOCK {
+				t.Errorf("Expected the file to be locked, but it is still lockable: %v", err)
+			}
+		})
+	}
 }

--- a/vendor/k8s.io/client-go/tools/watch/informerwatcher.go
+++ b/vendor/k8s.io/client-go/tools/watch/informerwatcher.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+func newEventProcessor(out chan<- watch.Event) *eventProcessor {
+	return &eventProcessor{
+		out:  out,
+		cond: sync.NewCond(&sync.Mutex{}),
+		done: make(chan struct{}),
+	}
+}
+
+// eventProcessor buffers events and writes them to an out chan when a reader
+// is waiting. Because of the requirement to buffer events, it synchronizes
+// input with a condition, and synchronizes output with a channels. It needs to
+// be able to yield while both waiting on an input condition and while blocked
+// on writing to the output channel.
+type eventProcessor struct {
+	out chan<- watch.Event
+
+	cond *sync.Cond
+	buff []watch.Event
+
+	done chan struct{}
+}
+
+func (e *eventProcessor) run() {
+	for {
+		batch := e.takeBatch()
+		e.writeBatch(batch)
+		if e.stopped() {
+			return
+		}
+	}
+}
+
+func (e *eventProcessor) takeBatch() []watch.Event {
+	e.cond.L.Lock()
+	defer e.cond.L.Unlock()
+
+	for len(e.buff) == 0 && !e.stopped() {
+		e.cond.Wait()
+	}
+
+	batch := e.buff
+	e.buff = nil
+	return batch
+}
+
+func (e *eventProcessor) writeBatch(events []watch.Event) {
+	for _, event := range events {
+		select {
+		case e.out <- event:
+		case <-e.done:
+			return
+		}
+	}
+}
+
+func (e *eventProcessor) push(event watch.Event) {
+	e.cond.L.Lock()
+	defer e.cond.L.Unlock()
+	defer e.cond.Signal()
+	e.buff = append(e.buff, event)
+}
+
+func (e *eventProcessor) stopped() bool {
+	select {
+	case <-e.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (e *eventProcessor) stop() {
+	close(e.done)
+	e.cond.Signal()
+}
+
+// NewIndexerInformerWatcher will create an IndexerInformer and wrap it into watch.Interface
+// so you can use it anywhere where you'd have used a regular Watcher returned from Watch method.
+// it also returns a channel you can use to wait for the informers to fully shutdown.
+func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (cache.Indexer, cache.Controller, watch.Interface, <-chan struct{}) {
+	ch := make(chan watch.Event)
+	w := watch.NewProxyWatcher(ch)
+	e := newEventProcessor(ch)
+
+	indexer, informer := cache.NewIndexerInformer(lw, objType, 0, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			e.push(watch.Event{
+				Type:   watch.Added,
+				Object: obj.(runtime.Object),
+			})
+		},
+		UpdateFunc: func(old, new interface{}) {
+			e.push(watch.Event{
+				Type:   watch.Modified,
+				Object: new.(runtime.Object),
+			})
+		},
+		DeleteFunc: func(obj interface{}) {
+			staleObj, stale := obj.(cache.DeletedFinalStateUnknown)
+			if stale {
+				// We have no means of passing the additional information down using
+				// watch API based on watch.Event but the caller can filter such
+				// objects by checking if metadata.deletionTimestamp is set
+				obj = staleObj.Obj
+			}
+
+			e.push(watch.Event{
+				Type:   watch.Deleted,
+				Object: obj.(runtime.Object),
+			})
+		},
+	}, cache.Indexers{})
+
+	go e.run()
+
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		defer e.stop()
+		informer.Run(w.StopChan())
+	}()
+
+	return indexer, informer, w, doneCh
+}

--- a/vendor/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/vendor/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// resourceVersionGetter is an interface used to get resource version from events.
+// We can't reuse an interface from meta otherwise it would be a cyclic dependency and we need just this one method
+type resourceVersionGetter interface {
+	GetResourceVersion() string
+}
+
+// RetryWatcher will make sure that in case the underlying watcher is closed (e.g. due to API timeout or etcd timeout)
+// it will get restarted from the last point without the consumer even knowing about it.
+// RetryWatcher does that by inspecting events and keeping track of resourceVersion.
+// Especially useful when using watch.UntilWithoutRetry where premature termination is causing issues and flakes.
+// Please note that this is not resilient to etcd cache not having the resource version anymore - you would need to
+// use Informers for that.
+type RetryWatcher struct {
+	lastResourceVersion string
+	watcherClient       cache.Watcher
+	resultChan          chan watch.Event
+	stopChan            chan struct{}
+	doneChan            chan struct{}
+	minRestartDelay     time.Duration
+}
+
+// NewRetryWatcher creates a new RetryWatcher.
+// It will make sure that watches gets restarted in case of recoverable errors.
+// The initialResourceVersion will be given to watch method when first called.
+func NewRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher) (*RetryWatcher, error) {
+	return newRetryWatcher(initialResourceVersion, watcherClient, 1*time.Second)
+}
+
+func newRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher, minRestartDelay time.Duration) (*RetryWatcher, error) {
+	switch initialResourceVersion {
+	case "", "0":
+		// TODO: revisit this if we ever get WATCH v2 where it means start "now"
+		//       without doing the synthetic list of objects at the beginning (see #74022)
+		return nil, fmt.Errorf("initial RV %q is not supported due to issues with underlying WATCH", initialResourceVersion)
+	default:
+		break
+	}
+
+	rw := &RetryWatcher{
+		lastResourceVersion: initialResourceVersion,
+		watcherClient:       watcherClient,
+		stopChan:            make(chan struct{}),
+		doneChan:            make(chan struct{}),
+		resultChan:          make(chan watch.Event, 0),
+		minRestartDelay:     minRestartDelay,
+	}
+
+	go rw.receive()
+	return rw, nil
+}
+
+func (rw *RetryWatcher) send(event watch.Event) bool {
+	// Writing to an unbuffered channel is blocking operation
+	// and we need to check if stop wasn't requested while doing so.
+	select {
+	case rw.resultChan <- event:
+		return true
+	case <-rw.stopChan:
+		return false
+	}
+}
+
+// doReceive returns true when it is done, false otherwise.
+// If it is not done the second return value holds the time to wait before calling it again.
+func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
+	watcher, err := rw.watcherClient.Watch(metav1.ListOptions{
+		ResourceVersion:     rw.lastResourceVersion,
+		AllowWatchBookmarks: true,
+	})
+	// We are very unlikely to hit EOF here since we are just establishing the call,
+	// but it may happen that the apiserver is just shutting down (e.g. being restarted)
+	// This is consistent with how it is handled for informers
+	switch err {
+	case nil:
+		break
+
+	case io.EOF:
+		// watch closed normally
+		return false, 0
+
+	case io.ErrUnexpectedEOF:
+		klog.V(1).InfoS("Watch closed with unexpected EOF", "err", err)
+		return false, 0
+
+	default:
+		msg := "Watch failed"
+		if net.IsProbableEOF(err) || net.IsTimeout(err) {
+			klog.V(5).InfoS(msg, "err", err)
+			// Retry
+			return false, 0
+		}
+
+		klog.ErrorS(err, msg)
+		// Retry
+		return false, 0
+	}
+
+	if watcher == nil {
+		klog.ErrorS(nil, "Watch returned nil watcher")
+		// Retry
+		return false, 0
+	}
+
+	ch := watcher.ResultChan()
+	defer watcher.Stop()
+
+	for {
+		select {
+		case <-rw.stopChan:
+			klog.V(4).InfoS("Stopping RetryWatcher.")
+			return true, 0
+		case event, ok := <-ch:
+			if !ok {
+				klog.V(4).InfoS("Failed to get event! Re-creating the watcher.", "resourceVersion", rw.lastResourceVersion)
+				return false, 0
+			}
+
+			// We need to inspect the event and get ResourceVersion out of it
+			switch event.Type {
+			case watch.Added, watch.Modified, watch.Deleted, watch.Bookmark:
+				metaObject, ok := event.Object.(resourceVersionGetter)
+				if !ok {
+					_ = rw.send(watch.Event{
+						Type:   watch.Error,
+						Object: &apierrors.NewInternalError(errors.New("retryWatcher: doesn't support resourceVersion")).ErrStatus,
+					})
+					// We have to abort here because this might cause lastResourceVersion inconsistency by skipping a potential RV with valid data!
+					return true, 0
+				}
+
+				resourceVersion := metaObject.GetResourceVersion()
+				if resourceVersion == "" {
+					_ = rw.send(watch.Event{
+						Type:   watch.Error,
+						Object: &apierrors.NewInternalError(fmt.Errorf("retryWatcher: object %#v doesn't support resourceVersion", event.Object)).ErrStatus,
+					})
+					// We have to abort here because this might cause lastResourceVersion inconsistency by skipping a potential RV with valid data!
+					return true, 0
+				}
+
+				// All is fine; send the non-bookmark events and update resource version.
+				if event.Type != watch.Bookmark {
+					ok = rw.send(event)
+					if !ok {
+						return true, 0
+					}
+				}
+				rw.lastResourceVersion = resourceVersion
+
+				continue
+
+			case watch.Error:
+				// This round trip allows us to handle unstructured status
+				errObject := apierrors.FromObject(event.Object)
+				statusErr, ok := errObject.(*apierrors.StatusError)
+				if !ok {
+					klog.Error(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
+					// Retry unknown errors
+					return false, 0
+				}
+
+				status := statusErr.ErrStatus
+
+				statusDelay := time.Duration(0)
+				if status.Details != nil {
+					statusDelay = time.Duration(status.Details.RetryAfterSeconds) * time.Second
+				}
+
+				switch status.Code {
+				case http.StatusGone:
+					// Never retry RV too old errors
+					_ = rw.send(event)
+					return true, 0
+
+				case http.StatusGatewayTimeout, http.StatusInternalServerError:
+					// Retry
+					return false, statusDelay
+
+				default:
+					// We retry by default. RetryWatcher is meant to proceed unless it is certain
+					// that it can't. If we are not certain, we proceed with retry and leave it
+					// up to the user to timeout if needed.
+
+					// Log here so we have a record of hitting the unexpected error
+					// and we can whitelist some error codes if we missed any that are expected.
+					klog.V(5).Info(spew.Sprintf("Retrying after unexpected error: %#+v", event.Object))
+
+					// Retry
+					return false, statusDelay
+				}
+
+			default:
+				klog.Errorf("Failed to recognize Event type %q", event.Type)
+				_ = rw.send(watch.Event{
+					Type:   watch.Error,
+					Object: &apierrors.NewInternalError(fmt.Errorf("retryWatcher failed to recognize Event type %q", event.Type)).ErrStatus,
+				})
+				// We are unable to restart the watch and have to stop the loop or this might cause lastResourceVersion inconsistency by skipping a potential RV with valid data!
+				return true, 0
+			}
+		}
+	}
+}
+
+// receive reads the result from a watcher, restarting it if necessary.
+func (rw *RetryWatcher) receive() {
+	defer close(rw.doneChan)
+	defer close(rw.resultChan)
+
+	klog.V(4).Info("Starting RetryWatcher.")
+	defer klog.V(4).Info("Stopping RetryWatcher.")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-rw.stopChan:
+			cancel()
+			return
+		case <-ctx.Done():
+			return
+		}
+	}()
+
+	// We use non sliding until so we don't introduce delays on happy path when WATCH call
+	// timeouts or gets closed and we need to reestablish it while also avoiding hot loops.
+	wait.NonSlidingUntilWithContext(ctx, func(ctx context.Context) {
+		done, retryAfter := rw.doReceive()
+		if done {
+			cancel()
+			return
+		}
+
+		timer := time.NewTimer(retryAfter)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+
+		klog.V(4).Infof("Restarting RetryWatcher at RV=%q", rw.lastResourceVersion)
+	}, rw.minRestartDelay)
+}
+
+// ResultChan implements Interface.
+func (rw *RetryWatcher) ResultChan() <-chan watch.Event {
+	return rw.resultChan
+}
+
+// Stop implements Interface.
+func (rw *RetryWatcher) Stop() {
+	close(rw.stopChan)
+}
+
+// Done allows the caller to be notified when Retry watcher stops.
+func (rw *RetryWatcher) Done() <-chan struct{} {
+	return rw.doneChan
+}

--- a/vendor/k8s.io/client-go/tools/watch/until.go
+++ b/vendor/k8s.io/client-go/tools/watch/until.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// PreconditionFunc returns true if the condition has been reached, false if it has not been reached yet,
+// or an error if the condition failed or detected an error state.
+type PreconditionFunc func(store cache.Store) (bool, error)
+
+// ConditionFunc returns true if the condition has been reached, false if it has not been reached yet,
+// or an error if the condition cannot be checked and should terminate. In general, it is better to define
+// level driven conditions over edge driven conditions (pod has ready=true, vs pod modified and ready changed
+// from false to true).
+type ConditionFunc func(event watch.Event) (bool, error)
+
+// ErrWatchClosed is returned when the watch channel is closed before timeout in UntilWithoutRetry.
+var ErrWatchClosed = errors.New("watch closed before UntilWithoutRetry timeout")
+
+// UntilWithoutRetry reads items from the watch until each provided condition succeeds, and then returns the last watch
+// encountered. The first condition that returns an error terminates the watch (and the event is also returned).
+// If no event has been received, the returned event will be nil.
+// Conditions are satisfied sequentially so as to provide a useful primitive for higher level composition.
+// Waits until context deadline or until context is canceled.
+//
+// Warning: Unless you have a very specific use case (probably a special Watcher) don't use this function!!!
+// Warning: This will fail e.g. on API timeouts and/or 'too old resource version' error.
+// Warning: You are most probably looking for a function *Until* or *UntilWithSync* below,
+// Warning: solving such issues.
+// TODO: Consider making this function private to prevent misuse when the other occurrences in our codebase are gone.
+func UntilWithoutRetry(ctx context.Context, watcher watch.Interface, conditions ...ConditionFunc) (*watch.Event, error) {
+	ch := watcher.ResultChan()
+	defer watcher.Stop()
+	var lastEvent *watch.Event
+	for _, condition := range conditions {
+		// check the next condition against the previous event and short circuit waiting for the next watch
+		if lastEvent != nil {
+			done, err := condition(*lastEvent)
+			if err != nil {
+				return lastEvent, err
+			}
+			if done {
+				continue
+			}
+		}
+	ConditionSucceeded:
+		for {
+			select {
+			case event, ok := <-ch:
+				if !ok {
+					return lastEvent, ErrWatchClosed
+				}
+				lastEvent = &event
+
+				done, err := condition(event)
+				if err != nil {
+					return lastEvent, err
+				}
+				if done {
+					break ConditionSucceeded
+				}
+
+			case <-ctx.Done():
+				return lastEvent, wait.ErrWaitTimeout
+			}
+		}
+	}
+	return lastEvent, nil
+}
+
+// Until wraps the watcherClient's watch function with RetryWatcher making sure that watcher gets restarted in case of errors.
+// The initialResourceVersion will be given to watch method when first called. It shall not be "" or "0"
+// given the underlying WATCH call issues (#74022).
+// Remaining behaviour is identical to function UntilWithoutRetry. (See above.)
+// Until can deal with API timeouts and lost connections.
+// It guarantees you to see all events and in the order they happened.
+// Due to this guarantee there is no way it can deal with 'Resource version too old error'. It will fail in this case.
+// (See `UntilWithSync` if you'd prefer to recover from all the errors including RV too old by re-listing
+// those items. In normal code you should care about being level driven so you'd not care about not seeing all the edges.)
+//
+// The most frequent usage for Until would be a test where you want to verify exact order of events ("edges").
+func Until(ctx context.Context, initialResourceVersion string, watcherClient cache.Watcher, conditions ...ConditionFunc) (*watch.Event, error) {
+	w, err := NewRetryWatcher(initialResourceVersion, watcherClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return UntilWithoutRetry(ctx, w, conditions...)
+}
+
+// UntilWithSync creates an informer from lw, optionally checks precondition when the store is synced,
+// and watches the output until each provided condition succeeds, in a way that is identical
+// to function UntilWithoutRetry. (See above.)
+// UntilWithSync can deal with all errors like API timeout, lost connections and 'Resource version too old'.
+// It is the only function that can recover from 'Resource version too old', Until and UntilWithoutRetry will
+// just fail in that case. On the other hand it can't provide you with guarantees as strong as using simple
+// Watch method with Until. It can skip some intermediate events in case of watch function failing but it will
+// re-list to recover and you always get an event, if there has been a change, after recovery.
+// Also with the current implementation based on DeltaFIFO, order of the events you receive is guaranteed only for
+// particular object, not between more of them even it's the same resource.
+// The most frequent usage would be a command that needs to watch the "state of the world" and should't fail, like:
+// waiting for object reaching a state, "small" controllers, ...
+func UntilWithSync(ctx context.Context, lw cache.ListerWatcher, objType runtime.Object, precondition PreconditionFunc, conditions ...ConditionFunc) (*watch.Event, error) {
+	indexer, informer, watcher, done := NewIndexerInformerWatcher(lw, objType)
+	// We need to wait for the internal informers to fully stop so it's easier to reason about
+	// and it works with non-thread safe clients.
+	defer func() { <-done }()
+	// Proxy watcher can be stopped multiple times so it's fine to use defer here to cover alternative branches and
+	// let UntilWithoutRetry to stop it
+	defer watcher.Stop()
+
+	if precondition != nil {
+		if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+			return nil, fmt.Errorf("UntilWithSync: unable to sync caches: %w", ctx.Err())
+		}
+
+		done, err := precondition(indexer)
+		if err != nil {
+			return nil, err
+		}
+
+		if done {
+			return nil, nil
+		}
+	}
+
+	return UntilWithoutRetry(ctx, watcher, conditions...)
+}
+
+// ContextWithOptionalTimeout wraps context.WithTimeout and handles infinite timeouts expressed as 0 duration.
+func ContextWithOptionalTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout < 0 {
+		// This should be handled in validation
+		klog.Errorf("Timeout for context shall not be negative!")
+		timeout = 0
+	}
+
+	if timeout == 0 {
+		return context.WithCancel(parent)
+	}
+
+	return context.WithTimeout(parent, timeout)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -684,6 +684,7 @@ k8s.io/client-go/tools/pager
 k8s.io/client-go/tools/record
 k8s.io/client-go/tools/record/util
 k8s.io/client-go/tools/reference
+k8s.io/client-go/tools/watch
 k8s.io/client-go/transport
 k8s.io/client-go/util/cert
 k8s.io/client-go/util/connrotation


### PR DESCRIPTION
Add the local lock to avoid deadlock when we enable the maxSurge rollingUpdate strategy as there will be two gpu-device-plugin running at the same time during the rollingUpdate. Use remote node status when there is no lock there to prevent deadlock though a little bit slower.