### PR TITLE
Revert using pod informer to connect to kube apiserver

### DIFF
--- a/pkg/gpu/nvidia/health_check/health_checker.go
+++ b/pkg/gpu/nvidia/health_check/health_checker.go
@@ -27,12 +27,8 @@ import (
 	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml"
 	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/scheme"
 	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	listersv1 "k8s.io/client-go/listers/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
@@ -60,9 +56,7 @@ type GPUHealthChecker struct {
 	monitorCriticalXid map[uint64]bool
 	kubeClient         client.Interface
 	nodeName           string
-	nodeLister         listersv1.NodeLister
 	recorder           record.EventRecorder
-	informerFactory    informers.SharedInformerFactory
 }
 
 // NewGPUHealthChecker returns a GPUHealthChecker object for a given device name
@@ -106,7 +100,7 @@ func NewGPUHealthChecker(devices map[string]pluginapi.Device, health chan plugin
 // 1. If the bootId changes, consider the node fixed through auto-repair
 // 2. If the bootId stay unchanged, consider a pure gpu-device-plugin restart
 func (hc *GPUHealthChecker) resetXIDCondition() error {
-	node, err := hc.nodeLister.Get(hc.nodeName)
+	node, err := hc.kubeClient.CoreV1().Nodes().Get(context.Background(), hc.nodeName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -140,23 +134,11 @@ func (hc *GPUHealthChecker) resetXIDCondition() error {
 
 // Start registers NVML events and starts listening to them
 func (hc *GPUHealthChecker) Start() error {
-	ctx := context.Background()
-	nodeName, err := metadata.InstanceNameWithContext(ctx)
+	nodeName, err := metadata.InstanceNameWithContext(context.Background())
 	if err != nil {
 		glog.Errorf("failed to get nodeName, err: %v", err)
 	}
 	hc.nodeName = nodeName
-	hc.informerFactory = informers.NewSharedInformerFactoryWithOptions(
-		hc.kubeClient,
-		0,
-		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", hc.nodeName).String()
-		}),
-	)
-
-	hc.nodeLister = hc.informerFactory.Core().V1().Nodes().Lister()
-	hc.informerFactory.Start(ctx.Done())
-	hc.informerFactory.WaitForCacheSync(wait.NeverStop)
 
 	err = hc.resetXIDCondition()
 	if err != nil {
@@ -282,7 +264,7 @@ func (hc *GPUHealthChecker) monitorXidevent(e nvml.Event) {
 	if _, ok := hc.monitorCriticalXid[e.Edata]; ok {
 		glog.Info("Monitoring XID event")
 		// Set XID condition
-		node, err := hc.nodeLister.Get(hc.nodeName)
+		node, err := hc.kubeClient.CoreV1().Nodes().Get(context.Background(), hc.nodeName, metav1.GetOptions{})
 		if err != nil {
 			glog.Errorf("Failed to get node %s: %v", hc.nodeName, err)
 			return
@@ -351,7 +333,7 @@ func (hc *GPUHealthChecker) setXIDheartbeat() {
 }
 
 func (hc *GPUHealthChecker) updateLastHeartbeatTime() {
-	node, err := hc.nodeLister.Get(hc.nodeName)
+	node, err := hc.kubeClient.CoreV1().Nodes().Get(context.Background(), hc.nodeName, metav1.GetOptions{})
 	if err != nil {
 		glog.Errorf("Failed to get node %s for heartbeat update: %v", hc.nodeName, err)
 		return
@@ -377,7 +359,7 @@ func (hc *GPUHealthChecker) updateLastHeartbeatTime() {
 }
 
 func (hc *GPUHealthChecker) recordXIDEvent(e nvml.Event) error {
-	node, err := hc.nodeLister.Get(hc.nodeName)
+	node, err := hc.kubeClient.CoreV1().Nodes().Get(context.Background(), hc.nodeName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -462,7 +444,6 @@ func (hc *GPUHealthChecker) listenToEvents() error {
 
 // Stop deletes the NVML events and stops the listening go routine
 func (hc *GPUHealthChecker) Stop() {
-	hc.informerFactory.Shutdown()
 	hc.recorder.(record.EventBroadcaster).Shutdown()
 	nvml.DeleteEventSet(hc.eventSet)
 	hc.stop <- true


### PR DESCRIPTION
* reverts informer changes in 6a3199876145b1b6281882cb2b55f6e83701499b
* `hc.informerFactory.Start(ctx.Done())` causes 30s timeout due to race with kube apiserver being ready in DPv2 fast start cases