### PR TITLE
Update debian-base for fastsocket-installer

### DIFF
--- a/fast-socket-installer/image/Dockerfile
+++ b/fast-socket-installer/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/gke-release/debian-base:bookworm-v1.0.5-gke.11
+FROM gcr.io/gke-release/debian-base:bookworm-v1.0.6-gke.1
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends --allow-change-held-packages apt-transport-https ca-certificates curl gnupg && \


### PR DESCRIPTION
This PR updates the debian-base image to bookworm-v1.0.6-gke.1 in the fastsocket-installer Dockerfile to address potential vulnerabilities in the base image.