### PR TITLE
Add multi-arch support for nri-device-injector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,11 @@ fastsocket_installer:
 nri-device-injector:
 	docker build --pull -t ${REGISTRY}/${DEVICE_INJECTOR_IMAGE}:${TAG} -f nri_device_injector/Dockerfile .
 
+nri-device-injector-multi-arch:
+	@for arch in $(ALL_ARCHITECTURES); do \
+	  docker buildx build --pull --load --platform linux/$${arch} -t ${REGISTRY}/${DEVICE_INJECTOR_IMAGE}-$${arch}:${TAG} -f nri_device_injector/Dockerfile . ; \
+	done
+
 nvidia_persistenced_installer:
 	docker buildx build --pull --load -t ${REGISTRY}/${NVIDIA_PERSISTENCED_IMAGE}:${TAG} -f nvidia-persistenced-installer/Dockerfile .
 


### PR DESCRIPTION
## What does this PR do?

Adds a `nri-device-injector-multi-arch` target for building amd64 & arm64 image targets for the `nri_device_injector`

## Tests

Validated build & push with:

```
_ADDONS_CONTAINER_REGISTRY=gcr.io/psch-gke-dev
_REPO_NAME=nri-device-injector
_TAG=v2

make nri-device-injector-multi-arch REGISTRY=${_ADDONS_CONTAINER_REGISTRY} DEVICE_INJECTOR_IMAGE=${_REPO_NAME} TAG=${_TAG}
make push-all REGISTRY=${_ADDONS_CONTAINER_REGISTRY} IMAGE=${_REPO_NAME} TAG=${_TAG}
make push-multi-arch REGISTRY=${_ADDONS_CONTAINER_REGISTRY} IMAGE=${_REPO_NAME} TAG=${_TAG}
```