### PR TITLE
fix(asapd): Make asapd-lite daemonset more robust

### DIFF
--- a/asapd-lite-installer/asapd-lite-installer-a4x-max-bm-cos.yaml
+++ b/asapd-lite-installer/asapd-lite-installer-a4x-max-bm-cos.yaml
@@ -41,7 +41,7 @@ spec:
       hostPID: true
       containers:
       - name: asapd-lite
-        image: us-docker.pkg.dev/gce-ai-infra/asapd-lite/asapd-lite:v0.0.1
+        image: us-docker.pkg.dev/gce-ai-infra/asapd-lite/asapd-lite:v0.0.2
 
         command: ["/bin/bash", "-c"]
         args:


### PR DESCRIPTION
- Use a wrapper script to run asapd-lite to handle restarts and failures gracefully.
- Add hostPID to allow debugging and interaction with host processes.
- Add mounts for systemd and fix udev rules path to allow better integration with the host.