### PR TITLE
fix: Parameterize number of nodes env var within a4x-max jobset

### DIFF
--- a/gpudirect-rdma/nccl-test-a4x-max-jobset.yaml
+++ b/gpudirect-rdma/nccl-test-a4x-max-jobset.yaml
@@ -98,7 +98,7 @@ spec:
                 - name: OMPI_ALLOW_RUN_AS_ROOT_CONFIRM
                   value: "1"
                 - name: N_NODES
-                  value: "2"
+                  value: "__NUM_NODES__"
                 - name: LD_LIBRARY_PATH
                   value: /usr/local/nvidia/lib64
                 command:


### PR DESCRIPTION
CC: @pwschuurman 
CC: @Jiaqicao257 