### PR TITLE
Replace duplicate and outdated `gpudirect-tcpx/nri-device-injector.yaml` with a symlink to the version in `nri_device_injector/`

### DIFF
--- a/gpudirect-tcpx/nri-device-injector.yaml
+++ b/gpudirect-tcpx/nri-device-injector.yaml
@@ -1,1 +1,0 @@
-../nri_device_injector/nri-device-injector.yaml


### PR DESCRIPTION
The version in `gpudirect-tcpx/` didn't receive a recent update to this daemonset in https://github.com/GoogleCloudPlatform/container-engine-accelerators/pull/539. As a result, our daemonset pods started crashing in a recent GKE node version breaking workloads with `tcpx-deamon` sidecar containers.

This PR ensures the two can't fall out of date.
