### PR TITLE
fix: use explicit COPY destination for ldconfig in nvidia-persistenced-installer

### DIFF
--- a/nvidia-persistenced-installer/Dockerfile
+++ b/nvidia-persistenced-installer/Dockerfile
@@ -33,6 +33,6 @@ RUN chmod a+x /go/src/github.com/GoogleCloudPlatform/container-engine-accelerato
 FROM marketplace.gcr.io/google/debian12 AS sbin_builder
 
 FROM gcr.io/distroless/base:latest
-COPY --from=sbin_builder /usr/sbin/ldconfig /usr/sbin
+COPY --from=sbin_builder /usr/sbin/ldconfig /usr/sbin/ldconfig
 COPY --from=builder /go/src/github.com/GoogleCloudPlatform/container-engine-accelerators/nvidia_persistenced_installer /usr/bin/nvidia-persistenced-installer
 CMD ["/usr/bin/nvidia-persistenced-installer", "-logtostderr"]


### PR DESCRIPTION
## Summary

Fix ambiguous Docker COPY destination in `nvidia-persistenced-installer/Dockerfile`.

## Problem

`COPY --from=sbin_builder /usr/sbin/ldconfig /usr/sbin` is ambiguous — if `/usr/sbin` does not exist as a directory in the base image, Docker creates a file named `/usr/sbin` instead of copying `ldconfig` into the directory. This causes `nvidia-persistenced-installer` to crash because `ldconfig` cannot be found at runtime.

## Fix

Use explicit destination `COPY ... /usr/sbin/ldconfig` which works regardless of base image directory structure.