### PR TITLE
emit nvidia driver version to node annotations

### DIFF
--- a/build/boilerplate/boilerplate.py
+++ b/build/boilerplate/boilerplate.py
@@ -138,7 +138,7 @@ def get_regexs():
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile( 'YEAR' )
     # dates can be 2014, 2015 or 2016, company holder names can be anything
-    regexs["date"] = re.compile( '(2014|2015|2016|2017|2018|2019|2020|2021|2023|2024|2025)' )
+    regexs["date"] = re.compile( '(2014|2015|2016|2017|2018|2019|2020|2021|2022|2023|2024|2025|2026)' )
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts

--- a/cmd/nvidia_gpu/nvidia_gpu.go
+++ b/cmd/nvidia_gpu/nvidia_gpu.go
@@ -15,16 +15,19 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"time"
 
 	gpumanager "github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia"
 	healthcheck "github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/health_check"
 	"github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/metrics"
 	util "github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/util"
+	versionvisibility "github.com/GoogleCloudPlatform/container-engine-accelerators/pkg/gpu/nvidia/version_visibility"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/golang/glog"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -50,6 +53,7 @@ var (
 	gpuMetricsPort                 = flag.Int("gpu-metrics-port", 2112, "Port on which GPU metrics for containers are exposed")
 	gpuMetricsCollectionIntervalMs = flag.Int("gpu-metrics-collection-interval", 30000, "Collection interval (in milli seconds) for container GPU metrics")
 	gpuConfigFile                  = flag.String("gpu-config", "/etc/nvidia/gpu_config.json", "File with GPU configurations for device plugin")
+	publishDriverVersion           = flag.Bool("publish-driver-version", false, "If true, the device plugin will publish NVIDIA driver versions to the Kubernetes Node annotation")
 )
 
 func parseGPUConfig(gpuConfigFile string) (gpumanager.GPUConfig, error) {
@@ -151,6 +155,31 @@ func main() {
 			return
 		}
 		defer hc.Stop()
+	}
+
+	if *publishDriverVersion {
+		glog.Infoln("Publishing NVIDIA driver version annotations to Node")
+		kubeClient, err := util.BuildKubeClient()
+		if err != nil {
+			glog.Warningf("Failed to build kube client for annotating: %v", err)
+		} else {
+			nodeName := os.Getenv("NODE_NAME")
+			if nodeName == "" {
+				glog.Warning("NODE_NAME environment variable not set, skipping publishing driver version annotations")
+			} else {
+				apiTimeout := 10 * time.Second
+				ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
+				defer cancel()
+				go func() {
+					err := versionvisibility.PublishDriverVersionAnnotations(ctx, kubeClient, nodeName)
+					if err != nil {
+						glog.Errorf("Failed to publish driver version annotations: %v", err)
+					} else {
+						glog.Info("Successfully published NVIDIA driver version annotations")
+					}
+				}()
+			}
+		}
 	}
 
 	ngm.Serve(*pluginMountPath, kubeletEndpoint, fmt.Sprintf("%s-%d.sock", pluginEndpointPrefix, time.Now().Unix()))

--- a/pkg/gpu/nvidia/version_visibility/version_visibility.go
+++ b/pkg/gpu/nvidia/version_visibility/version_visibility.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version_visibility
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/golang/glog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	DriverVersionPrefix   = "cloud.google.com/cuda.driver-version"
+	DriverVersionMajor    = DriverVersionPrefix + ".major"
+	DriverVersionMinor    = DriverVersionPrefix + ".minor"
+	DriverVersionRevision = DriverVersionPrefix + ".revision"
+	DriverVersionFull     = DriverVersionPrefix + ".full"
+)
+
+// PublishDriverVersionAnnotations queries the NVIDIA driver version via NVML and publishes it as annotations to the Kubernetes Node object.
+func PublishDriverVersionAnnotations(ctx context.Context, kubeClient kubernetes.Interface, nodeName string) error {
+	version, ret := nvml.SystemGetDriverVersion()
+	if ret != nvml.SUCCESS {
+		return fmt.Errorf("failed to get driver version from NVML: %v", nvml.ErrorString(ret))
+	}
+
+	glog.Infof("Found NVIDIA Driver Version: %s", version)
+	return patchNodeAnnotations(ctx, kubeClient, nodeName, parseDriverAnnotations(version))
+}
+
+func parseDriverAnnotations(version string) map[string]string {
+	annotations := map[string]string{
+		DriverVersionFull: version,
+	}
+
+	parts := strings.Split(version, ".")
+	if len(parts) >= 1 {
+		annotations[DriverVersionMajor] = parts[0]
+	}
+	if len(parts) >= 2 {
+		annotations[DriverVersionMinor] = parts[1]
+	}
+	if len(parts) >= 3 {
+		annotations[DriverVersionRevision] = parts[2]
+	}
+
+	return annotations
+}
+
+func patchNodeAnnotations(ctx context.Context, kubeClient kubernetes.Interface, nodeName string, annotations map[string]string) error {
+	if nodeName == "" {
+		return fmt.Errorf("node name is empty")
+	}
+
+	nodeApplyConfiguration := corev1apply.Node(nodeName).
+		WithAnnotations(annotations)
+
+	glog.Infof("Applying node %s annotations using SSA: %v", nodeName, annotations)
+	_, err := kubeClient.CoreV1().Nodes().Apply(
+		ctx,
+		nodeApplyConfiguration,
+		metav1.ApplyOptions{FieldManager: "gpu-device-plugin", Force: true},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to apply node %s annotations: %v", nodeName, err)
+	}
+
+	return nil
+}

--- a/pkg/gpu/nvidia/version_visibility/version_visibility_test.go
+++ b/pkg/gpu/nvidia/version_visibility/version_visibility_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version_visibility
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestParseDriverAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		expected map[string]string
+	}{
+		{
+			name:    "Full version",
+			version: "550.107.02",
+			expected: map[string]string{
+				DriverVersionFull:     "550.107.02",
+				DriverVersionMajor:    "550",
+				DriverVersionMinor:    "107",
+				DriverVersionRevision: "02",
+			},
+		},
+		{
+			name:    "Major only",
+			version: "550",
+			expected: map[string]string{
+				DriverVersionFull:  "550",
+				DriverVersionMajor: "550",
+			},
+		},
+		{
+			name:    "Major and Minor",
+			version: "550.107",
+			expected: map[string]string{
+				DriverVersionFull:  "550.107",
+				DriverVersionMajor: "550",
+				DriverVersionMinor: "107",
+			},
+		},
+		{
+			name:    "Extra parts",
+			version: "550.107.02.04",
+			expected: map[string]string{
+				DriverVersionFull:     "550.107.02.04",
+				DriverVersionMajor:    "550",
+				DriverVersionMinor:    "107",
+				DriverVersionRevision: "02",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			annotations := parseDriverAnnotations(tc.version)
+			if len(annotations) != len(tc.expected) {
+				t.Errorf("expected %d annotations, got %d", len(tc.expected), len(annotations))
+			}
+			for k, v := range tc.expected {
+				if annotations[k] != v {
+					t.Errorf("expected annotation %s=%s, got %s", k, v, annotations[k])
+				}
+			}
+		})
+	}
+}
+
+func TestPatchNodeAnnotations(t *testing.T) {
+	nodeName := "test-node"
+	kubeClient := fake.NewSimpleClientset()
+
+	// Create initial node
+	_, err := kubeClient.CoreV1().Nodes().Create(context.Background(), &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Annotations: map[string]string{
+				"existing-label": "value",
+				"cloud.google.com/cuda.driver-version.major": "510",
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	annotations := map[string]string{
+		"cloud.google.com/cuda.driver-version.major": "550",
+		"cloud.google.com/cuda.driver-version.full":  "550.107.02",
+	}
+
+	err = patchNodeAnnotations(context.Background(), kubeClient, nodeName, annotations)
+	if err != nil {
+		t.Fatalf("patchNodeAnnotations failed: %v", err)
+	}
+
+	// Verify node annotations
+	node, err := kubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+
+	for k, v := range annotations {
+		if node.Annotations[k] != v {
+			t.Errorf("expected annotation %s=%s, got %s", k, v, node.Annotations[k])
+		}
+	}
+
+	if node.Annotations["existing-label"] != "value" {
+		t.Errorf("expected existing annotation to be preserved")
+	}
+}


### PR DESCRIPTION
This change publishes nvidia gpu driver version as node annotation
```
  ...
Annotations:        cloud.google.com/cuda.driver-version.full: 580.105.08
                    cloud.google.com/cuda.driver-version.major: 580
                    cloud.google.com/cuda.driver-version.minor: 105
                    cloud.google.com/cuda.driver-version.revision: 08
                    container.googleapis.com/instance_id: 1343450457406822318
  ...
```

Requires `NODE_NAME` env var set appropriately and `patch` added to rbac rules:
```yml
- name: NODE_NAME
  valueFrom:
    fieldRef:
      fieldPath: spec.nodeName
```
```yml
rules:
- apiGroups: [""]
  resources: ["nodes"]
  verbs: ["get", "list", "watch", "patch"]
```
The patching logic is implemented in a non-blocking manner; it runs in a separate goroutine, ensuring that even if the kube client fails to initialize, the node name is missing, or the annotation patching process encounters an error, the main GPU device plugin functionality remains unaffected and continues to serve normally.

## Tested
Nodepool upgrade with auto install:  
new nodes are created, behaves normally as fresh start.

Manual installation - default -> manual installation - latest -> `sudo reboot`:  
The default versions are correctly emitted. After the reboot, the new latest versions are correctly emitted.