### PR TITLE
some arguments are removed from `tcpgpudmarxd-dev` container

### DIFF
--- a/gpudirect-tcpxo/nccl-test-latest-autopilot.yaml
+++ b/gpudirect-tcpxo/nccl-test-latest-autopilot.yaml
@@ -69,7 +69,7 @@ spec:
   subdomain: nccl-host-1
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.17
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -190,7 +190,7 @@ spec:
   subdomain: nccl-host-2
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.17
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:

--- a/gpudirect-tcpxo/nccl-test-latest.yaml
+++ b/gpudirect-tcpxo/nccl-test-latest.yaml
@@ -87,7 +87,7 @@ spec:
         - |
           set -ex
           chmod 755 /fts/entrypoint_rxdm_container.sh
-          /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=8
+          /fts/entrypoint_rxdm_container.sh --num_hops=2
       securityContext:
         #        privileged: true
         capabilities:
@@ -217,7 +217,7 @@ spec:
         - |
           set -ex
           chmod 755 /fts/entrypoint_rxdm_container.sh
-          /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=8
+          /fts/entrypoint_rxdm_container.sh --num_hops=2
       securityContext:
         #        privileged: true
         capabilities:

--- a/gpudirect-tcpxo/nccl-test-unprivileged-without-hostnetwork.yaml
+++ b/gpudirect-tcpxo/nccl-test-unprivileged-without-hostnetwork.yaml
@@ -73,7 +73,7 @@ spec:
         - |
           set -ex
           chmod 755 /fts/entrypoint_rxdm_container.sh
-          /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=8
+          /fts/entrypoint_rxdm_container.sh --num_hops=2
       securityContext:
 #        privileged: true
         capabilities:
@@ -203,7 +203,7 @@ spec:
         - |
           set -ex
           chmod 755 /fts/entrypoint_rxdm_container.sh
-          /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=8
+          /fts/entrypoint_rxdm_container.sh --num_hops=2
       securityContext:
         #        privileged: true
         capabilities:

--- a/gpudirect-tcpxo/nccl-test.yaml
+++ b/gpudirect-tcpxo/nccl-test.yaml
@@ -48,7 +48,7 @@ spec:
         - |
           set -ex
           chmod 755 /fts/entrypoint_rxdm_container.sh
-          /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=8
+          /fts/entrypoint_rxdm_container.sh --num_hops=2
       securityContext:
         privileged: true
       volumeMounts:
@@ -129,7 +129,7 @@ spec:
         - |
           set -ex
           chmod 755 /fts/entrypoint_rxdm_container.sh
-          /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=8
+          /fts/entrypoint_rxdm_container.sh --num_hops=2
       securityContext:
         privileged: true
       volumeMounts:


### PR DESCRIPTION
1. revert `tcpgpudmarxd-dev` version used in nccl-latest-autopilot to 1.0.17
2. remove num_nics from other tcpxo yamls.