### PR TITLE
Remove 'exit 0' from nccl-test script

### DIFF
--- a/gpudirect-rdma/nccl-test-a4x-max-jobset.yaml
+++ b/gpudirect-rdma/nccl-test-a4x-max-jobset.yaml
@@ -159,8 +159,6 @@ spec:
                       sleep 5
                     done
                   fi
-
-                  exit 0
                 volumeMounts:
                 - name: nvidia
                   mountPath: /usr/local/nvidia


### PR DESCRIPTION
Having 'exit 0' at the end of the script masks any errors generated and allows pods to exit with "success"/"completed" status instead of failing.