### PR TITLE
bump tcpxo-daemon version to 1.0.21 and remove deprecated flags

### DIFF
--- a/gpudirect-tcpxo/nccl-test-latest-autopilot.yaml
+++ b/gpudirect-tcpxo/nccl-test-latest-autopilot.yaml
@@ -69,14 +69,14 @@ spec:
   subdomain: nccl-host-1
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.17
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
         - |
           set -ex
           chmod 755 /fts/entrypoint_rxdm_container.sh
-          /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=8 --enforce_kernel_ipv6_support=false
+          /fts/entrypoint_rxdm_container.sh --num_hops=2
       securityContext:
         capabilities:
           add:
@@ -190,14 +190,14 @@ spec:
   subdomain: nccl-host-2
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.17
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
         - |
           set -ex
           chmod 755 /fts/entrypoint_rxdm_container.sh
-          /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=8 --enforce_kernel_ipv6_support=false
+          /fts/entrypoint_rxdm_container.sh --num_hops=2
       securityContext:
         capabilities:
           add:


### PR DESCRIPTION
The flags `--num_nics` and `--enforce_kernel_ipv6_support` are deprecated.

manually validated on AP and standard on `a3-megagpu-8g`.