### PR TITLE
Release Apr 30, 2026

### DIFF
--- a/gpudirect-tcpxo/README.md
+++ b/gpudirect-tcpxo/README.md
@@ -37,6 +37,7 @@ For best practices, refer to [Best practice to run workload with GPUDirect-TCPX(
 
 
 ## Releases
+- [Apr 30, 2026](./README.md#apr-30-2026)
 - [Jan 9, 2026](./README.md#jan-9-2026)
 - [Nov 19, 2025](./README.md#nov-19-2025)
 - [Aug 21, 2025](./README.md#aug-21-2025)
@@ -53,6 +54,59 @@ For best practices, refer to [Best practice to run workload with GPUDirect-TCPX(
 - [May 30, 2024](./README.md#may-30-2024)
 - [May 20, 2024](./README.md#may-20-2024)
 - [Apr 17, 2024](./README.md#apr-17-2024)
+
+## Apr 30, 2026
+#### NCCL plugin installer image:
+```
+us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
+```
+#### TCPXO-daemon image:
+```
+us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
+```
+#### Compatible NCCL version:
+```
+Default NCCl version: nccl-2.28, which is provided by the NCCL plugin installer
+qualified and supported: NCCL 2.28.7-1
+```
+#### NCCL configs:
+```
+"NCCL_FASTRAK_CTRL_DEV=eth0",
+"NCCL_FASTRAK_IFNAME=eth1,eth2,eth3,eth4,eth5,eth6,eth7,eth8",
+"NCCL_SOCKET_IFNAME=eth0",
+"NCCL_CROSS_NIC=0",
+"NCCL_PROTO=Simple,LL128",
+
+"NCCL_MIN_NCHANNELS=4",
+"NCCL_TUNER_PLUGIN=libnccl-tuner.so",
+"NCCL_TUNER_CONFIG_PATH=/usr/local/tcpxo/lib64/a3plus_tuner_config.textproto",
+# Please replace `/usr/local/tcpxo/lib64/` as the NCCL lib directory installd inside the workload container,
+# the mounted library path are controlled in nccl installer destination, link. 
+"NCCL_SHIMNET_GUEST_CONFIG_CHECKER_CONFIG_FILE=/usr/local/tcpxo/lib64/a3plus_guest_config.textproto",
+# Please replace `/usr/local/tcpxo/lib64/` as the NCCL lib directory installed inside the workload container.
+# the mounted library path are controlled in nccl installer destination, link.
+"CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7",
+"NCCL_NVLSTREE_MAX_CHUNKSIZE=131072",
+"NCCL_P2P_NET_CHUNKSIZE=524288",
+"NCCL_P2P_PCI_CHUNKSIZE=524288",
+"NCCL_P2P_NVL_CHUNKSIZE=1048576",
+"NCCL_FASTRAK_NUM_FLOWS=2",
+"NCCL_FASTRAK_USE_SNAP=1",
+"NCCL_FASTRAK_PLUGIN_ACCEPT_TIMEOUT_MS=600000",
+"NCCL_FASTRAK_ENABLE_CONTROL_CHANNEL=0",
+"NCCL_BUFFSIZE=8388608",
+"NCCL_NET_GDR_LEVEL=PIX",
+"NCCL_FASTRAK_ENABLE_HOTPATH_LOGGING=0",
+"NCCL_FASTRAK_USE_LLCM=1",
+"NCCL_NVLS_ENABLE=1"
+"NCCL_DEBUG=WARN",
+"NCCL_DEBUG_SUBSYS=INIT,NET,ENV,COLL,GRAPH"
+```
+#### What is new with in release:
+* Hide all symbols except the NCCL plugin symbols in Net Plugin
+  * Customers building the net plugin from source will need to update the tag of precompiled-libs from v1.0.1 to v1.0.4
+* Updated the Guest Config Checker to the load correct plugin name
+  * uninitialized_shim_v7 no longer appears in NCCL logs
 
 ## Jan 9, 2026
 #### NCCL plugin installer image:

--- a/gpudirect-tcpxo/nccl-tcpxo-installer-autopilot.yaml
+++ b/gpudirect-tcpxo/nccl-tcpxo-installer-autopilot.yaml
@@ -73,7 +73,7 @@ spec:
                   chmod a+rw /dev/aperture_devices/*/resource*
               fi
         - name: nccl-tcpxo-installer
-          image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+          image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
           resources:
             limits:
               cpu: 50m

--- a/gpudirect-tcpxo/nccl-tcpxo-installer.yaml
+++ b/gpudirect-tcpxo/nccl-tcpxo-installer.yaml
@@ -69,7 +69,7 @@ spec:
                   chmod a+rw /dev/aperture_devices/*/resource*
               fi
         - name: nccl-tcpxo-installer
-          image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+          image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
           resources:
             requests:
               cpu: 150m

--- a/gpudirect-tcpxo/nccl-test-latest-autopilot.yaml
+++ b/gpudirect-tcpxo/nccl-test-latest-autopilot.yaml
@@ -69,7 +69,7 @@ spec:
   subdomain: nccl-host-1
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -90,7 +90,7 @@ spec:
         - name: proc-sys
           mountPath: /hostprocsysfs
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
       imagePullPolicy: Always
       command:
         - /bin/sh
@@ -190,7 +190,7 @@ spec:
   subdomain: nccl-host-2
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -211,7 +211,7 @@ spec:
         - name: proc-sys
           mountPath: /hostprocsysfs
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
       imagePullPolicy: Always
       command:
         - /bin/sh

--- a/gpudirect-tcpxo/nccl-test-latest.yaml
+++ b/gpudirect-tcpxo/nccl-test-latest.yaml
@@ -80,7 +80,7 @@ spec:
   #  dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -105,7 +105,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
       imagePullPolicy: Always
       #      securityContext:
       #        privileged: true
@@ -210,7 +210,7 @@ spec:
   #  dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -235,7 +235,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
       imagePullPolicy: Always
       #      securityContext:
       #        privileged: true

--- a/gpudirect-tcpxo/nccl-test-unprivileged-without-hostnetwork.yaml
+++ b/gpudirect-tcpxo/nccl-test-unprivileged-without-hostnetwork.yaml
@@ -66,7 +66,7 @@ spec:
   #  dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -91,7 +91,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
       imagePullPolicy: Always
 #      securityContext:
 #        privileged: true
@@ -196,7 +196,7 @@ spec:
   #  dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -221,7 +221,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
       imagePullPolicy: Always
 #      securityContext:
 #        privileged: true

--- a/gpudirect-tcpxo/nccl-test.yaml
+++ b/gpudirect-tcpxo/nccl-test.yaml
@@ -41,7 +41,7 @@ spec:
   dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -58,7 +58,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
       imagePullPolicy: Always
       command:
         - /bin/sh
@@ -122,7 +122,7 @@ spec:
   dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -139,7 +139,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
       imagePullPolicy: Always
       command:
         - /bin/sh


### PR DESCRIPTION
Bump tcpxo-daemon image to v1.0.22 and nccl-plugin-gpudirecttcpx-dev image to v1.0.16 and update release notes.

GPUDirect TCPXO Guest Release: April 30th, 2026 Release Candidate