### PR TITLE
feat: add GPU UUID and Device ID to XID error events

### DIFF
--- a/pkg/gpu/nvidia/health_check/health_checker.go
+++ b/pkg/gpu/nvidia/health_check/health_checker.go
@@ -389,12 +389,13 @@ func (hc *GPUHealthChecker) recordXIDEvent(e nvml.Event, cd callDevice) error {
 		return err
 	}
 
-	var msg string
-	if e.UUID == nil || len(*e.UUID) == 0 {
-		msg = fmt.Sprintf("Caught XID error, XID=%d", e.Edata)
-	} else {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Caught XID error, XID=%d", e.Edata)
+
+	if e.UUID != nil && len(*e.UUID) > 0 {
 		var affectedGpuIDs []string
 		var affectedGpuUUIDs []string
+
 		for _, d := range hc.devices {
 			nvmlDev, ok := hc.nvmlDevices[d.ID]
 			if !ok || nvmlDev == nil {
@@ -414,13 +415,16 @@ func (hc *GPUHealthChecker) recordXIDEvent(e nvml.Event, cd callDevice) error {
 				affectedGpuUUIDs = append(affectedGpuUUIDs, uuid)
 			}
 		}
+
 		if len(affectedGpuIDs) > 0 {
-			msg = fmt.Sprintf("Caught XID error, XID=%d, GPU UUID=%s, Device ID=%s", e.Edata, strings.Join(affectedGpuUUIDs, ", "), strings.Join(affectedGpuIDs, ", "))
+			fmt.Fprintf(&sb, ", GPU UUID=%s", strings.Join(affectedGpuUUIDs, ", "))
+			fmt.Fprintf(&sb, ", Device ID=%s", strings.Join(affectedGpuIDs, ", "))
 		} else {
-			msg = fmt.Sprintf("Caught XID error, XID=%d, GPU UUID=%s", e.Edata, *e.UUID)
+			fmt.Fprintf(&sb, ", GPU UUID=%s", *e.UUID)
 		}
 	}
 
+	msg := sb.String()
 	hc.recorder.Eventf(node, v1.EventTypeWarning, "XIDError", msg)
 	return nil
 }

--- a/pkg/gpu/nvidia/health_check/health_checker.go
+++ b/pkg/gpu/nvidia/health_check/health_checker.go
@@ -383,12 +383,45 @@ func (hc *GPUHealthChecker) updateLastHeartbeatTime() {
 	}
 }
 
-func (hc *GPUHealthChecker) recordXIDEvent(e nvml.Event) error {
+func (hc *GPUHealthChecker) recordXIDEvent(e nvml.Event, cd callDevice) error {
 	node, err := hc.kubeClient.CoreV1().Nodes().Get(context.Background(), hc.nodeName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
-	hc.recorder.Eventf(node, v1.EventTypeWarning, "XIDError", "Caught XID error, XID=%d", e.Edata)
+
+	var msg string
+	if e.UUID == nil || len(*e.UUID) == 0 {
+		msg = fmt.Sprintf("Caught XID error, XID=%d", e.Edata)
+	} else {
+		var affectedGpuIDs []string
+		var affectedGpuUUIDs []string
+		for _, d := range hc.devices {
+			nvmlDev, ok := hc.nvmlDevices[d.ID]
+			if !ok || nvmlDev == nil {
+				continue
+			}
+			uuid := nvmlDev.UUID
+			gpu, gi, ci, err := cd.parseMigDeviceUUID(uuid)
+			if err != nil {
+				gpu = uuid
+				gi = 0xFFFFFFFF
+				ci = 0xFFFFFFFF
+			}
+
+			if e.GpuInstanceId != nil && e.ComputeInstanceId != nil &&
+				gpu == *e.UUID && gi == *e.GpuInstanceId && ci == *e.ComputeInstanceId {
+				affectedGpuIDs = append(affectedGpuIDs, d.ID)
+				affectedGpuUUIDs = append(affectedGpuUUIDs, uuid)
+			}
+		}
+		if len(affectedGpuIDs) > 0 {
+			msg = fmt.Sprintf("Caught XID error, XID=%d, GPU UUID=%s, Device ID=%s", e.Edata, strings.Join(affectedGpuUUIDs, ", "), strings.Join(affectedGpuIDs, ", "))
+		} else {
+			msg = fmt.Sprintf("Caught XID error, XID=%d, GPU UUID=%s", e.Edata, *e.UUID)
+		}
+	}
+
+	hc.recorder.Eventf(node, v1.EventTypeWarning, "XIDError", msg)
 	return nil
 }
 
@@ -399,7 +432,7 @@ func (hc *GPUHealthChecker) catchError(e nvml.Event, cd callDevice) {
 		return
 	}
 
-	err := hc.recordXIDEvent(e)
+	err := hc.recordXIDEvent(e, cd)
 	if err != nil {
 		glog.Errorf("Failed to record XID=%d for node %s with err %v", e.Edata, hc.nodeName, err)
 	}

--- a/pkg/gpu/nvidia/health_check/health_checker_test.go
+++ b/pkg/gpu/nvidia/health_check/health_checker_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8sclienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
@@ -478,4 +479,88 @@ func makeNode(labels map[string]string, annotations map[string]string, condition
 		node.Status.Conditions = conditions
 	}
 	return node
+}
+
+func TestRecordXIDEvent(t *testing.T) {
+	node := makeNode(nil, nil, nil)
+	fakeClient := fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node}})
+	fakeRecorder := record.NewFakeRecorder(10)
+
+	gp := mockGPUDevice{}
+	device1 := pluginapi.Device{ID: "nvidia0"}
+	device2 := pluginapi.Device{ID: "nvidia1"}
+
+	tests := []struct {
+		name          string
+		event         nvml.Event
+		devices       map[string]pluginapi.Device
+		nvmlDevices   map[string]*nvml.Device
+		expectedEvent string
+	}{
+		{
+			name: "event with no UUID",
+			event: nvml.Event{
+				Edata: uint64(72),
+			},
+			expectedEvent: "Warning XIDError Caught XID error, XID=72",
+		},
+		{
+			name: "event with UUID matching a device",
+			event: nvml.Event{
+				UUID:              pointer("GPU-1"),
+				GpuInstanceId:     pointer(uint(3173334309191009974)),
+				ComputeInstanceId: pointer(uint(1015241)),
+				Edata:             uint64(72),
+			},
+			devices: map[string]pluginapi.Device{
+				"nvidia0": device1,
+				"nvidia1": device2,
+			},
+			nvmlDevices: map[string]*nvml.Device{
+				"nvidia0": {UUID: "GPU-1"},
+				"nvidia1": {UUID: "GPU-2"},
+			},
+			expectedEvent: "Warning XIDError Caught XID error, XID=72, GPU UUID=GPU-1, Device ID=nvidia0",
+		},
+		{
+			name: "event with UUID matching no devices",
+			event: nvml.Event{
+				UUID:              pointer("GPU-3"),
+				GpuInstanceId:     pointer(uint(3173334309191009974)),
+				ComputeInstanceId: pointer(uint(1015241)),
+				Edata:             uint64(72),
+			},
+			devices: map[string]pluginapi.Device{
+				"nvidia0": device1,
+			},
+			nvmlDevices: map[string]*nvml.Device{
+				"nvidia0": {UUID: "GPU-1"},
+			},
+			expectedEvent: "Warning XIDError Caught XID error, XID=72, GPU UUID=GPU-3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hc := &GPUHealthChecker{
+				devices:     tt.devices,
+				nvmlDevices: tt.nvmlDevices,
+				kubeClient:  fakeClient,
+				nodeName:    "test-node",
+				recorder:    fakeRecorder,
+			}
+			err := hc.recordXIDEvent(tt.event, &gp)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			select {
+			case gotEvent := <-fakeRecorder.Events:
+				if gotEvent != tt.expectedEvent {
+					t.Errorf("expected event %q, got %q", tt.expectedEvent, gotEvent)
+				}
+			case <-time.After(100 * time.Millisecond):
+				t.Errorf("expected event %q but none was recorded", tt.expectedEvent)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Unit tests passed.
Manually validated on a live GKE cluster using the illegal-memory-access demo pod.
<img width="1406" height="86" alt="Screenshot 2026-06-17 at 11 56 26 AM" src="https://github.com/user-attachments/assets/fc6b5d53-7119-475d-ade8-6539a5d082e8" />
