### PR TITLE
Update GPUDirect-TCPXO plugin image to v1.0.17 and RxDM to v1.0.23

### DIFF
--- a/gpudirect-tcpxo/README.md
+++ b/gpudirect-tcpxo/README.md
@@ -37,6 +37,7 @@ For best practices, refer to [Best practice to run workload with GPUDirect-TCPX(
 
 
 ## Releases
+- [Jun 26, 2026](./README.md#jun-26-2026)
 - [Apr 30, 2026](./README.md#apr-30-2026)
 - [Jan 9, 2026](./README.md#jan-9-2026)
 - [Nov 19, 2025](./README.md#nov-19-2025)
@@ -55,6 +56,69 @@ For best practices, refer to [Best practice to run workload with GPUDirect-TCPX(
 - [May 20, 2024](./README.md#may-20-2024)
 - [Apr 17, 2024](./README.md#apr-17-2024)
 
+
+## Jun 26, 2026
+#### NCCL plugin installer image:
+```
+us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.17
+```
+#### TCPXO-daemon image:
+```
+us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.23
+```
+#### Precompiled Libraries Image:
+```
+us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirect-tcpxo-precompiled-libs:v1.0.5
+```
+#### Compatible NCCL version:
+```
+On COS/GKE and Debian, NCCL 2.28.7-1 is qualified and supported on GPU driver 595.71.05 with CUDA 13.2.
+```
+
+#### Compatible GPU driver version:
+Please make sure to use GPU driver version `595.71.05` and above. For GKE, please follow the instructions [here](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#installing_drivers), and use `1.33.5-gke.1125000` release or above and specify the following flag: `gpu-driver-version=R595`
+
+#### Compatible OS versions:
+Starting from v1.0.9, glibc version 2.35 or higher is required.
+- Workloads running on COS M105 will have to upgrade to COS M109 or higher
+- Containers based on Ubuntu 20.04 will need to be upgraded to Ubuntu 22.04 or higher
+- Debian containers must be upgraded to Debian 12
+
+#### NCCL configs:
+```
+"LD_LIBRARY_PATH=\"${LD_LIBRARY_PATH}:/usr/local/tcpxo/lib64\"",
+"NCCL_FASTRAK_IFNAME=eth1,eth2,eth3,eth4,eth5,eth6,eth7,eth8",
+"NCCL_FASTRAK_CTRL_DEV=eth0",
+"NCCL_SOCKET_IFNAME=eth0",
+"NCCL_CROSS_NIC=0",
+"NCCL_PROTO=Simple,LL128",
+"NCCL_MIN_NCHANNELS=4",
+"NCCL_NVLSTREE_MAX_CHUNKSIZE=131072",
+"NCCL_P2P_NET_CHUNKSIZE=524288",
+"NCCL_P2P_PCI_CHUNKSIZE=524288",
+"NCCL_P2P_NVL_CHUNKSIZE=1048576",
+"NCCL_FASTRAK_NUM_FLOWS=2",
+"NCCL_FASTRAK_ENABLE_CONTROL_CHANNEL=0",
+"NCCL_BUFFSIZE=8388608",
+"NCCL_FASTRAK_USE_SNAP=1",
+"NCCL_FASTRAK_USE_LLCM=1",
+"CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7",
+"NCCL_NET_GDR_LEVEL=PIX",
+"NCCL_FASTRAK_ENABLE_HOTPATH_LOGGING=0",
+"NCCL_TUNER_PLUGIN=libnccl-tuner.so",
+"NCCL_TUNER_CONFIG_PATH=/usr/local/tcpxo/lib64/a3plus_tuner_config.textproto",
+"NCCL_SHIMNET_GUEST_CONFIG_CHECKER_CONFIG_FILE=/usr/local/tcpxo/lib64/a3plus_guest_config.textproto",
+"NCCL_FASTRAK_PLUGIN_ACCEPT_TIMEOUT_MS=600000",
+"NCCL_DEBUG=WARN",
+"NCCL_DEBUG_SUBSYS=INIT,NET,ENV,COLL,GRAPH",
+"NCCL_NVLS_ENABLE=1",
+"NCCL_NET_PLUGIN_TELEMETRY_MODE=0"
+```
+#### Notes:
+- gpudirect-tcpxo release notes: [v1.0.17](https://github.com/google/nccl-plugin-gpudirect-tcpxo/releases/tag/v1.0.17)
+- This release has been qualified with CUDA 13.2, GPU driver 595.71.05, and NCCL 2.28.7-1
+- Support for using the [Collective coMMunications Analyzer (CoMMA)](https://github.com/google/CoMMA) with FasTrak has been added with this release.
+- Tuner plugin resiliency improvements
 
 ## Apr 30, 2026
 #### NCCL plugin installer image:

--- a/gpudirect-tcpxo/nccl-tcpxo-installer-autopilot.yaml
+++ b/gpudirect-tcpxo/nccl-tcpxo-installer-autopilot.yaml
@@ -73,7 +73,7 @@ spec:
                   chmod a+rw /dev/aperture_devices/*/resource*
               fi
         - name: nccl-tcpxo-installer
-          image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
+          image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.17
           resources:
             limits:
               cpu: 50m

--- a/gpudirect-tcpxo/nccl-tcpxo-installer.yaml
+++ b/gpudirect-tcpxo/nccl-tcpxo-installer.yaml
@@ -69,7 +69,7 @@ spec:
                   chmod a+rw /dev/aperture_devices/*/resource*
               fi
         - name: nccl-tcpxo-installer
-          image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
+          image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.17
           resources:
             requests:
               cpu: 150m

--- a/gpudirect-tcpxo/nccl-test-latest-autopilot.yaml
+++ b/gpudirect-tcpxo/nccl-test-latest-autopilot.yaml
@@ -69,7 +69,7 @@ spec:
   subdomain: nccl-host-1
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.23
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -90,7 +90,7 @@ spec:
         - name: proc-sys
           mountPath: /hostprocsysfs
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.17
       imagePullPolicy: Always
       command:
         - /bin/sh
@@ -190,7 +190,7 @@ spec:
   subdomain: nccl-host-2
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.23
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -211,7 +211,7 @@ spec:
         - name: proc-sys
           mountPath: /hostprocsysfs
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.17
       imagePullPolicy: Always
       command:
         - /bin/sh

--- a/gpudirect-tcpxo/nccl-test-latest.yaml
+++ b/gpudirect-tcpxo/nccl-test-latest.yaml
@@ -80,7 +80,7 @@ spec:
   #  dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.23
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -105,7 +105,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.17
       imagePullPolicy: Always
       #      securityContext:
       #        privileged: true
@@ -210,7 +210,7 @@ spec:
   #  dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.23
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -235,7 +235,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.17
       imagePullPolicy: Always
       #      securityContext:
       #        privileged: true

--- a/gpudirect-tcpxo/nccl-test-unprivileged-without-hostnetwork.yaml
+++ b/gpudirect-tcpxo/nccl-test-unprivileged-without-hostnetwork.yaml
@@ -66,7 +66,7 @@ spec:
   #  dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.23
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -91,7 +91,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.17
       imagePullPolicy: Always
 #      securityContext:
 #        privileged: true
@@ -196,7 +196,7 @@ spec:
   #  dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.23
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -221,7 +221,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.17
       imagePullPolicy: Always
 #      securityContext:
 #        privileged: true

--- a/gpudirect-tcpxo/nccl-test.yaml
+++ b/gpudirect-tcpxo/nccl-test.yaml
@@ -41,7 +41,7 @@ spec:
   dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.23
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -58,7 +58,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.17
       imagePullPolicy: Always
       command:
         - /bin/sh
@@ -122,7 +122,7 @@ spec:
   dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: tcpxo-daemon
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.22
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.23
       imagePullPolicy: Always
       command: ["/bin/sh", "-c"]
       args:
@@ -139,7 +139,7 @@ spec:
         - name: LD_LIBRARY_PATH
           value: /usr/local/nvidia/lib64
     - name: nccl-test
-      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.16
+      image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.17
       imagePullPolicy: Always
       command:
         - /bin/sh


### PR DESCRIPTION
Update GPUDirect-TCPXO nccl-plugin image tag to v1.0.17 and tcpgpudmarxd image tag to v1.0.23 across all manifest files and README.md.